### PR TITLE
fix: Ignore casing differences between song titles

### DIFF
--- a/src/pages/cover/[slug].astro
+++ b/src/pages/cover/[slug].astro
@@ -40,7 +40,7 @@ const { data: cover } = await supabase
 const { created_at, description, contributor } = data;
 
 let coveredAs;
-if (original?.name !== cover?.name) {
+if (original?.name.toLowerCase() !== cover?.name.toLowerCase()) {
   coveredAs = cover?.name;
 }
 


### PR DESCRIPTION
When showing "covered as" titles that differ from the original title, ignore casing.

Before: (original title "Big in Japan" with lowercase 'i')
<img width="381" alt="image" src="https://github.com/evadecker/genderswap.fm/assets/4117920/47e18076-934d-42c3-940c-91b21d54d287">

After:
<img width="456" alt="image" src="https://github.com/evadecker/genderswap.fm/assets/4117920/646dd66c-c83c-4d34-8036-673e50862498">