### PR TITLE
feat: Add random feature and route

### DIFF
--- a/src/components/TagCloud.astro
+++ b/src/components/TagCloud.astro
@@ -1,21 +1,9 @@
 ---
-import Tag from "../components/Tag.astro";
-import { TAGS } from "../types/tags";
-import type { Enums } from "../types/types";
 
-type Props = {
-  tags: Enums<"tags">[];
-};
-
-const { tags } = Astro.props;
 ---
 
 <div class="tags">
-  {
-    tags.map((tag) => (
-      <Tag text={TAGS[tag].label} url={`/tagged/${TAGS[tag].slug}`} />
-    ))
-  }
+  <slot />
 </div>
 
 <style>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -18,17 +18,44 @@ import BaseLayout from "../layouts/BaseLayout.astro";
       ></path>
     </svg>
     <h1>Not Found</h1>
+    <a href="/random" class="button">Get random cover</a>
   </div>
 </BaseLayout>
 
-<style>
+<style lang="scss">
   .container {
     display: flex;
     flex-direction: column;
     align-items: center;
     justify-content: center;
     gap: var(--space-xl);
+    padding-block: var(--space-2xl);
     flex: 1;
     height: 100%;
+  }
+
+  .button {
+    background: var(--mauve-12);
+    color: var(--mauve-1);
+    border: none;
+    cursor: pointer;
+    border-radius: var(--radius-full);
+    padding-block: var(--space-s);
+    padding-inline: var(--space-xl);
+    margin-inline: auto;
+    font-size: var(--step-1);
+    font-weight: var(--font-weight-bold);
+
+    @media (hover: hover) and (pointer: fine) {
+      &:hover {
+        background: var(--violet-9);
+        color: white;
+      }
+    }
+
+    &:focus {
+      outline: 3px solid var(--violet-a9);
+      outline-offset: 3px;
+    }
   }
 </style>

--- a/src/pages/cover/[slug].astro
+++ b/src/pages/cover/[slug].astro
@@ -7,6 +7,8 @@ import dayjs from "dayjs";
 import { getReadableTitle } from "../../helpers/helpers";
 import type { Enums, Tables } from "../../types/types";
 import TagCloud from "../../components/TagCloud.astro";
+import Tag from "../../components/Tag.astro";
+import { TAGS } from "../../types/tags";
 
 const { slug } = Astro.params;
 
@@ -60,7 +62,13 @@ const formattedDate = dayjs(created_at).format("MMMM D, YYYY");
 
 <BaseLayout title={title} description={description!!}>
   <PageHeader title={original.name} description={description}>
-    <TagCloud tags={tags} />
+    <TagCloud>
+      {
+        tags.map((tag) => (
+          <Tag text={TAGS[tag].label} url={`/tagged/${TAGS[tag].slug}`} />
+        ))
+      }
+    </TagCloud>
   </PageHeader>
   <CoverComparison cover={data} />
   <footer class="footer">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,6 +2,7 @@
 import CoverCardGrid from "../components/CoverCardGrid.astro";
 import PageHeader from "../components/PageHeader.astro";
 import Tag from "../components/Tag.astro";
+import TagCloud from "../components/TagCloud.astro";
 import BaseLayout from "../layouts/BaseLayout.astro";
 import { supabase } from "../lib/supabase";
 
@@ -25,7 +26,10 @@ const { data: covers } = await supabase
     title="Genderswap.fm"
     description="Some covers deliver the age-old simple pleasures of drag."
   >
-    <Tag text="Explore by tag" url="/tagged" />
+    <TagCloud>
+      <Tag text="Explore by tag" url="/tagged" />
+      <Tag text="Get random cover" url="/random" />
+    </TagCloud>
   </PageHeader>
   <CoverCardGrid covers={covers as any} />
 </BaseLayout>

--- a/src/pages/random.astro
+++ b/src/pages/random.astro
@@ -1,0 +1,7 @@
+---
+import { supabase } from "../lib/supabase";
+
+const { data: randomSlug } = await supabase.rpc("get_random_cover_slug");
+
+return Astro.redirect(`/cover/${randomSlug}`);
+---

--- a/src/pages/tagged/index.astro
+++ b/src/pages/tagged/index.astro
@@ -4,6 +4,7 @@ import BaseLayout from "../../layouts/BaseLayout.astro";
 import TagCloud from "../../components/TagCloud.astro";
 import { TAGS } from "../../types/tags";
 import { type Enums } from "../../types/types";
+import Tag from "../../components/Tag.astro";
 
 const tags = Object.keys(TAGS) as Enums<"tags">[];
 
@@ -17,7 +18,13 @@ const description = "Find covers that are…";
 >
   <PageHeader title={title} description={description} />
   <div class="tags">
-    <TagCloud tags={tags} />
+    <TagCloud>
+      {
+        tags.map((tag) => (
+          <Tag text={TAGS[tag].label} url={`/tagged/${TAGS[tag].slug}`} />
+        ))
+      }
+    </TagCloud>
   </div>
 </BaseLayout>
 
@@ -26,5 +33,6 @@ const description = "Find covers that are…";
     margin-inline: auto;
     padding-inline: var(--space-xl);
     max-width: 60ch;
+    padding-block-end: var(--space-3xl);
   }
 </style>

--- a/src/types/db-generated.types.ts
+++ b/src/types/db-generated.types.ts
@@ -135,22 +135,10 @@ export interface Database {
       [_ in never]: never
     }
     Functions: {
-      generate_tags_initial:
-        | {
-            Args: {
-              original_id: string
-              cover_id: string
-            }
-            Returns: undefined
-          }
-        | {
-            Args: {
-              original_id: string
-              cover_id: string
-              target_table: string
-            }
-            Returns: undefined
-          }
+      get_random_cover_slug: {
+        Args: Record<PropertyKey, never>
+        Returns: string
+      }
     }
     Enums: {
       gender: "male" | "female" | "other"


### PR DESCRIPTION
- Add https://genderswap.fm/random route which calls a function in Supabase that returns a random cover slug
- Add random button to 404
- Add random button to main index
- Refactor TagCloud component to accept children
- Add space beneath tags on `/tagged`
- Add space beneath 404
- Resolves #29 