### PR TITLE
fix: Compare slugified titles for equality to conditionally show "covered as"

### DIFF
--- a/src/components/CoverComparison.astro
+++ b/src/components/CoverComparison.astro
@@ -1,4 +1,5 @@
 ---
+import { slugify } from "../helpers/helpers";
 import type { Cover } from "../pages/cover/[slug].astro";
 import Icon from "./Icon.astro";
 
@@ -10,7 +11,7 @@ const { cover } = Astro.props;
 const { original: originalSong, cover: coverSong } = cover;
 
 let coveredAs;
-if (originalSong.name.toLowerCase() !== coverSong.name.toLowerCase()) {
+if (slugify(originalSong.name) !== slugify(coverSong.name)) {
   coveredAs = coverSong.name;
 }
 ---

--- a/src/helpers/helpers.ts
+++ b/src/helpers/helpers.ts
@@ -40,22 +40,22 @@ export const removeSongExtraText = (song: string) => {
   return songNoExtras;
 };
 
-export const slugifyCover = (name: string, artist: string) => {
-  const slugify = (str: string) => {
-    return (
-      str
-        .normalize("NFKD") // split accented characters into their base characters and diacritical marks
-        .replace(/[\u0300-\u036f]/g, "") // remove all the accents, which happen to be all in the \u03xx UNICODE block.
-        .trim() // trim leading or trailing whitespace
-        .toLowerCase() // convert to lowercase
-        // remove . , " ' “ ” ‘ ’ # ! $ %  & * ; : = _ ` ~ | { } ( ) [ ] ^ *
-        .replace(/[.,"'“”‘’#!?$%&%;:=_`~|{}()[\]\^\*]/g, "")
-        .replace(/\/+/g, "-") // replace forward slashes with hyphens
-        .replace(/\s+/g, "-") // replace spaces with hyphens
-        .replace(/-+/g, "-") // remove consecutive hyphens
-    );
-  };
+export const slugify = (str: string) => {
+  return (
+    str
+      .normalize("NFKD") // split accented characters into their base characters and diacritical marks
+      .replace(/[\u0300-\u036f]/g, "") // remove all the accents, which happen to be all in the \u03xx UNICODE block.
+      .trim() // trim leading or trailing whitespace
+      .toLowerCase() // convert to lowercase
+      // remove . , " ' “ ” ‘ ’ # ! $ %  & * ; : = _ ` ~ | { } ( ) [ ] ^ *
+      .replace(/[.,"'“”‘’#!?$%&%;:=_`~|{}()[\]\^\*]/g, "")
+      .replace(/\/+/g, "-") // replace forward slashes with hyphens
+      .replace(/\s+/g, "-") // replace spaces with hyphens
+      .replace(/-+/g, "-") // remove consecutive hyphens
+  );
+};
 
+export const slugifyCover = (name: string, artist: string) => {
   const slug = `${slugify(removeSongExtraText(name))}-${slugify(artist)}`;
   return slug;
 };


### PR DESCRIPTION
- Compare the slugified titles of songs in order to remove any differences in punctuation (straight quote vs curly quote, ends in exclamation vs not, etc.)
- Fixes #45 