### PR TITLE
feat: Mark pages as statically rendered

### DIFF
--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,5 +1,8 @@
 ---
 import BaseLayout from "../layouts/BaseLayout.astro";
+
+// Static page
+export const prerender = true;
 ---
 
 <BaseLayout title="Not Found" description="This page could not be found.">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -3,7 +3,6 @@ import CoverCardGrid from "../components/CoverCardGrid.astro";
 import PageHeader from "../components/PageHeader.astro";
 import Tag from "../components/Tag.astro";
 import TagCloud from "../components/TagCloud.astro";
-import { slugifyCover } from "../helpers/helpers";
 import BaseLayout from "../layouts/BaseLayout.astro";
 import { supabase } from "../lib/supabase";
 

--- a/src/pages/new/index.astro
+++ b/src/pages/new/index.astro
@@ -2,6 +2,9 @@
 import Container from "../../components/Container.astro";
 import { SubmitForm } from "../../components/SubmitForm/SubmitForm";
 import BaseLayout from "../../layouts/BaseLayout.astro";
+
+// Static page
+export const prerender = true;
 ---
 
 <BaseLayout title="Submit a cover · Genderswap.fm">

--- a/src/pages/tagged/index.astro
+++ b/src/pages/tagged/index.astro
@@ -6,6 +6,9 @@ import { TAGS } from "../../types/tags";
 import { type Enums } from "../../types/types";
 import Tag from "../../components/Tag.astro";
 
+// Static page
+export const prerender = true;
+
 const tags = Object.keys(TAGS) as Enums<"tags">[];
 
 const title = "Explore by tag";


### PR DESCRIPTION
- Mark certain routes as `export const prerender = true;` to pre-render static pages
- Resolves #78 