### PR TITLE
fix: Use baseline alignment

### DIFF
--- a/src/components/Tag.astro
+++ b/src/components/Tag.astro
@@ -28,7 +28,7 @@ const { text, count, url } = Astro.props;
   .tag {
     display: inline-flex;
     gap: var(--space-xs);
-    align-items: center;
+    align-items: baseline;
     background: var(--mauve-3);
     color: var(--mauve-11);
     padding-block: var(--space-2xs);


### PR DESCRIPTION
- Align `Tag` text to baseline