### PR TITLE
feat: Use lazysizes

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "classnames": "^2.3.2",
     "dayjs": "^1.11.10",
     "downshift": "^8.2.2",
+    "lazysizes": "^5.3.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.47.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ dependencies:
   downshift:
     specifier: ^8.2.2
     version: 8.2.2(react@18.2.0)
+  lazysizes:
+    specifier: ^5.3.2
+    version: 5.3.2
   react:
     specifier: ^18.2.0
     version: 18.2.0
@@ -4303,6 +4306,10 @@ packages:
     dependencies:
       language-subtag-registry: 0.3.22
     dev: true
+
+  /lazysizes@5.3.2:
+    resolution: {integrity: sha512-22UzWP+Vedi/sMeOr8O7FWimRVtiNJV2HCa+V8+peZOw6QbswN9k58VUhd7i6iK5bw5QkYrF01LJbeJe0PV8jg==}
+    dev: false
 
   /levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}

--- a/src/components/CoversGrid/CoverCard.svelte
+++ b/src/components/CoversGrid/CoverCard.svelte
@@ -23,12 +23,22 @@
   <div class="albums">
     <div class="album">
       {#if original?.album_img}
-        <img src={original.album_img[1]} alt={`${original.name} album art`} />
+        <img
+          data-src={original.album_img[1]}
+          src={original.album_img[2]}
+          alt={`${original.name} album art`}
+          class="lazyload"
+        />
       {/if}
     </div>
     <div class="album">
       {#if cover?.album_img}
-        <img src={cover.album_img[1]} alt={`${cover.name} album art`} />
+        <img
+          data-src={cover.album_img[1]}
+          src={cover.album_img[2]}
+          alt={`${cover.name} album art`}
+          class="lazyload"
+        />
       {/if}
     </div>
   </div>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -69,6 +69,9 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
   </head>
   <body transition:animate="none">
     <script is:inline src="/scripts/preloadTheme.js"></script>
+    <script>
+      import "lazysizes";
+    </script>
     <Header />
     <main class="main" transition:animate="fade">
       <slot />


### PR DESCRIPTION
- Lazyload album images to improve performance
- Load the low-quality Spotify image before loading higher-quality art
- Resolves #100 (?)