### PR TITLE
fix: Get `totalCovers` count from `fetchCovers` call

### DIFF
--- a/src/components/CoversGrid/CoversGrid.svelte
+++ b/src/components/CoversGrid/CoversGrid.svelte
@@ -23,20 +23,6 @@
   let isFirst = page === 1;
   let isLast = false;
 
-  const getTotalCovers = async () => {
-    const covers = supabase
-      .from("covers")
-      .select("id", { count: "exact", head: true });
-
-    if (filterBy) {
-      covers.overlaps("tags", [filterBy]);
-    }
-
-    const { count } = await covers;
-
-    if (count) totalCovers = count;
-  };
-
   const fetchCovers = async () => {
     if (isLoading) return;
     isLoading = true;
@@ -53,7 +39,8 @@
           slug,
           original:original_id(id, name, artists, album_name, album_img),
           cover:cover_id(id, name, artists, album_name, album_img)
-        `
+        `,
+          { count: "exact" }
         )
         .order("created_at", { ascending: false })
         .range(newFrom, newTo);
@@ -62,9 +49,10 @@
         covers.overlaps("tags", [filterBy]);
       }
 
-      const { data } = await covers.returns<GridItem[]>();
+      const { data, count } = await covers.returns<GridItem[]>();
 
       if (data) loadedCovers = [...loadedCovers, ...data];
+      if (count) totalCovers = count;
       if (!data || data.length < COVERS_PER_PAGE) isLast = true;
 
       isLoading = false;
@@ -74,7 +62,6 @@
   };
 
   fetchCovers();
-  getTotalCovers();
 
   const handleBack = () => {
     const searchParams = new URLSearchParams(window.location.search);

--- a/src/components/CoversGrid/CoversGrid.svelte
+++ b/src/components/CoversGrid/CoversGrid.svelte
@@ -40,7 +40,7 @@
           original:original_id(id, name, artists, album_name, album_img),
           cover:cover_id(id, name, artists, album_name, album_img)
         `,
-          { count: "exact" }
+          { count: "estimated" }
         )
         .order("created_at", { ascending: false })
         .range(newFrom, newTo);


### PR DESCRIPTION
- Reduce the number of calls to the database