### PR TITLE
feat: Remove Typekit, use `system-ui` font

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -5,7 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <meta name="color-scheme" content="dark light" />
     <meta name="theme-color" content="#FEFCFB" />
-    <link rel="preconnect" href="https://use.typekit.net" crossorigin />
     <link rel="icon" href="%sveltekit.assets%/favicon.svg" type="image/svg+xml" />
     <link
       rel="icon"
@@ -21,7 +20,6 @@
     />
     <link rel="apple-touch-icon" href="%sveltekit.assets%/apple-touch-icon.png" />
     <link rel="manifest" href="%sveltekit.assets%/manifest.json" />
-    <link rel="stylesheet" href="https://use.typekit.net/hjc0gsm.css" />
     <title>Genderswap.fm</title>
     <meta property="og:type" content="website" />
     <meta property="og:locale" content="en_US" />

--- a/src/lib/components/Logo.svelte
+++ b/src/lib/components/Logo.svelte
@@ -91,7 +91,7 @@
   }
 
   .logo {
-    width: calc(var(--space-2xl) * 2.5);
+    width: calc(var(--space-2xl) * 3);
     height: auto;
     pointer-events: auto;
 
@@ -138,10 +138,12 @@
 
   .gender-bg {
     fill: var(--mauve-12);
+    mix-blend-mode: difference;
   }
 
   .swap-bg {
     fill: var(--mauve-12);
+    mix-blend-mode: difference;
   }
 
   .gender-letter,

--- a/src/lib/components/Tag.svelte
+++ b/src/lib/components/Tag.svelte
@@ -30,8 +30,8 @@
     background: var(--mauve-3);
     color: var(--mauve-11);
     padding-block: var(--space-2xs);
-    padding-inline: var(--space-m);
-    border-radius: var(--radius-full);
+    padding-inline: var(--space-s);
+    border-radius: var(--radius-s);
     font-size: var(--step-0);
     flex-shrink: 0;
     text-wrap: nowrap;

--- a/src/lib/styles/theme.css
+++ b/src/lib/styles/theme.css
@@ -23,8 +23,7 @@
 
 :root {
   /* Font families */
-  --font-sans: indivisible, system-ui, -apple-system, 'Segoe UI', roboto, 'Helvetica Neue',
-    sans-serif, serif;
+  --font-sans: system-ui, -apple-system, 'Segoe UI', roboto, 'Helvetica Neue', sans-serif, serif;
 
   /* @link https://utopia.fyi/type/calculator?c=320,16,1.2,1240,22,1.333,5,2,&s=0.75|0.5|0.25,1.5|2|3|4|6,s-l&g=s,l,xl,12 */
   --step--1: clamp(0.8331rem, 0.7642rem + 0.3446vw, 1.0313rem);

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -1,6 +1,5 @@
-import { TAGS } from '$lib/constants';
 import { supabase } from '$lib/supabase';
-import type { Enums, Tables } from '$lib/types/types';
+import type { Tables } from '$lib/types/types';
 
 type GridItem = {
   original: Tables<'songs'>;
@@ -8,7 +7,7 @@ type GridItem = {
   slug: string;
 };
 
-const PAGE_SIZE = 60;
+const PAGE_SIZE = 40;
 
 export async function load({ url }) {
   const page = Number(url.searchParams.get('page') ?? 1);

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -198,7 +198,6 @@
     background: var(--mauve-3);
     color: var(--mauve-11);
     padding-inline: var(--space-s);
-    font-size: var(--step--1);
     border-radius: var(--radius-s);
 
     &:first-child {


### PR DESCRIPTION
- No Typekit; speed up page loads by using local fonts
- Make tags on detail pages round rectangles, like the tags on the homepage
- Increase logo size
- Increase filter bar tag sizes
- Reduce page size from 60 covers to 40 covers, for performance