### PR TITLE
fix: Do not overwrite search query when input is focused

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -56,14 +56,14 @@
       newURL.searchParams.delete('q');
     }
 
-    debounce(() => goto(newURL, { keepFocus: true }));
+    debounce(() => goto(newURL, { keepFocus: true, replaceState: true }));
   };
 
   const handleClearSearch = () => {
     const newURL = new URL($page.url);
     newURL.searchParams.delete('tag');
     newURL.searchParams.delete('q');
-    goto(newURL, { keepFocus: true });
+    goto(newURL, { keepFocus: true, replaceState: true });
   };
 
   const handleKeydown: KeyboardEventHandler<HTMLInputElement> = (e) => {


### PR DESCRIPTION
- Sometimes multiple `goto` calls could be made independently and resolve after the user had typed, resulting in text being overwritten in the input
- This checks if the search `isFocused` before making any changes to user input
- Thanks @paoloricciuti for the fix!
- Sets `replaceState: true` on search-related `goto()` calls in order to prevent the browser's back button from capturing and replaying debounced search queries