### PR TITLE
fix: Prevent pasting newlines into description input

### DIFF
--- a/src/routes/new/+page.svelte
+++ b/src/routes/new/+page.svelte
@@ -26,17 +26,16 @@
 
   const handleDescriptionInput: FormEventHandler<HTMLTextAreaElement> = (e) => {
     $form.description = e.currentTarget.value;
-    // Replace any newlines in form.description with a space
-    $form.description = $form.description.replace(/\r?\n|\r/g, ' ');
-    // Trim spaces
-    $form.description = $form.description.trim();
+    // Replace any newlines with spaces and trim
+    $form.description = $form.description.replace(/\r?\n|\r/g, ' ').trim();
+
+    $form.description = $form.description;
   };
 
-  const handleContributorKeyDown = (event: KeyboardEvent) => {
-    // Prevent leading spaces
-    if ($form.contributor.length === 0 && event.key === ' ') {
-      event.preventDefault();
-    }
+  const handleContributorInput: FormEventHandler<HTMLInputElement> = (e) => {
+    $form.contributor = e.currentTarget.value;
+    // Trim spaces
+    $form.contributor = $form.contributor.trim();
   };
 
   const handleSubmit = () => {
@@ -97,7 +96,7 @@
           Your first name <span class="optional">optional</span>
         </div>
         <input
-          on:keydown={handleContributorKeyDown}
+          on:input={handleContributorInput}
           bind:value={$form.contributor}
           name="contributor"
           type="text"

--- a/src/routes/new/+page.svelte
+++ b/src/routes/new/+page.svelte
@@ -12,6 +12,7 @@
   import { browser } from '$app/environment';
   import { page } from '$app/stores';
   import LoaderIcon from '~icons/ri/loader-4-line';
+  import type { FormEventHandler } from 'svelte/elements';
 
   export let data: PageData;
 
@@ -23,16 +24,12 @@
 
   $form.contributor = browser ? window.localStorage.getItem('contributor') ?? '' : '';
 
-  const handleDescriptionKeyDown = (event: KeyboardEvent) => {
-    // Prevent newlines
-    if (event.key === 'Enter') {
-      event.preventDefault();
-    }
-
-    // Prevent leading spaces
-    if ($form.description.length === 0 && event.key === ' ') {
-      event.preventDefault();
-    }
+  const handleDescriptionInput: FormEventHandler<HTMLTextAreaElement> = (e) => {
+    $form.description = e.currentTarget.value;
+    // Replace any newlines in form.description with a space
+    $form.description = $form.description.replace(/\r?\n|\r/g, ' ');
+    // Trim spaces
+    $form.description = $form.description.trim();
   };
 
   const handleContributorKeyDown = (event: KeyboardEvent) => {
@@ -79,7 +76,7 @@
           Description <span class="optional">optional</span>
         </div>
         <textarea
-          on:keydown={handleDescriptionKeyDown}
+          on:input={handleDescriptionInput}
           bind:value={$form.description}
           use:autosize
           name="description"


### PR DESCRIPTION
- Update description and contributor input handlers
- Prevent pasting or typing newlines into description `textarea`
- `trim()` spaces in both contributor and description inputs
- Eliminates need for setting `on:keydown`
- Resolves #129 