### PR TITLE
Fix: Intelligently size fallback fonts

### DIFF
--- a/src/lib/styles/theme.css
+++ b/src/lib/styles/theme.css
@@ -64,8 +64,8 @@
 @font-face {
   font-family: 'Labil Grotesk fallback';
   font-style: normal;
-  font-weight: 700;
-  src: local('Arial');
+  font-weight: bold;
+  src: local('Arial Bold');
   ascent-override: 102%;
   descent-override: 23%;
   line-gap-override: normal;

--- a/src/lib/styles/theme.css
+++ b/src/lib/styles/theme.css
@@ -48,10 +48,33 @@
     url('/fonts/LabilGrotesk-Bold.woff') format('woff');
 }
 
+/* Font fallbacks */
+/* Manually sized via https://screenspan.net/fallback */
+@font-face {
+  font-family: 'Labil Grotesk fallback';
+  font-style: normal;
+  font-weight: 400;
+  src: local('Arial');
+  size-adjust: 101%;
+  ascent-override: 102%;
+  descent-override: 23%;
+  line-gap-override: normal;
+}
+
+@font-face {
+  font-family: 'Labil Grotesk fallback';
+  font-style: normal;
+  font-weight: 700;
+  src: local('Arial Black');
+  size-adjust: 82%;
+  ascent-override: 124%;
+  descent-override: 34%;
+  line-gap-override: normal;
+}
+
 :root {
   /* Font families */
-  --font-sans: 'Labil Grotesk', system-ui, -apple-system, 'Segoe UI', roboto, 'Helvetica Neue',
-    sans-serif, serif;
+  --font-sans: 'Labil Grotesk', 'Labil Grotesk fallback', system-ui, sans-serif;
 
   --font-stable: 'salt' off;
   --font-unstable: 'salt' 1, 'ss01' 1, 'ss02' 1, 'ss03' 1, 'ss04' 1;

--- a/src/lib/styles/theme.css
+++ b/src/lib/styles/theme.css
@@ -65,10 +65,9 @@
   font-family: 'Labil Grotesk fallback';
   font-style: normal;
   font-weight: 700;
-  src: local('Arial Black');
-  size-adjust: 82%;
-  ascent-override: 124%;
-  descent-override: 34%;
+  src: local('Arial');
+  ascent-override: 102%;
+  descent-override: 23%;
   line-gap-override: normal;
 }
 

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -27,4 +27,5 @@ const config = {
     })
   }
 };
+
 export default config;


### PR DESCRIPTION
- Use `size-adjust`, `ascent-override`, `descent-override`, etc. to intelligently set fallback fonts
- Manually set via https://screenspan.net/fallback
- Resolves #112 