### PR TITLE
fix: Put preloadTheme before contents to prevent flash of unstyled content

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -27,7 +27,7 @@
     %sveltekit.head%
   </head>
   <body data-sveltekit-preload-data="hover">
-    <div style="display: contents">%sveltekit.body%</div>
     <script src="%sveltekit.assets%/scripts/preloadTheme.js"></script>
+    <div style="display: contents">%sveltekit.body%</div>
   </body>
 </html>


### PR DESCRIPTION
- Resolves #114 