### PR TITLE
feat: Add getEarliestRelease API to check for prior song releases

### DIFF
--- a/src/lib/components/SongPreview.svelte
+++ b/src/lib/components/SongPreview.svelte
@@ -12,11 +12,11 @@
   export let onUseEarlierRelease: (e) => void;
   export let onClearSelection: () => void;
 
-  let useEarlierReleaseClicked = false;
+  let wasEarlierReleaseClicked = false;
 
   const handleUseEarlierRelease: MouseEventHandler<HTMLButtonElement> = (e) => {
     onUseEarlierRelease(e);
-    useEarlierReleaseClicked = true;
+    wasEarlierReleaseClicked = true;
   };
 </script>
 
@@ -38,7 +38,7 @@
   {#await earlierRelease then earlier}
     {#if earlier}
       <div class="earlierReleaseBanner" transition:slide>
-        {#if earlier.id === song.id || useEarlierReleaseClicked}
+        {#if earlier.id === song.id || wasEarlierReleaseClicked}
           <div class="bannerContents">
             <CheckIcon />
             <div class="bannerLabel">

--- a/src/lib/components/SongPreview.svelte
+++ b/src/lib/components/SongPreview.svelte
@@ -1,43 +1,102 @@
 <script lang="ts">
   import { smartquotes } from '$lib/helpers';
   import type { Track } from '@spotify/web-api-ts-sdk';
+  import { fade, slide } from 'svelte/transition';
   import CloseCircleIcon from '~icons/ri/close-circle-line';
+  import HistoryIcon from '~icons/ri/history-line';
+  import CheckIcon from '~icons/ri/check-line';
+  import type { MouseEventHandler } from 'svelte/elements';
 
   export let song: Track;
+  export let earlierRelease: Promise<Track | null> | null = null;
+  export let onUseEarlierRelease: (e) => void;
   export let onClearSelection: () => void;
+
+  let useEarlierReleaseClicked = false;
+
+  const getYearsBefore = (selectedReleaseDate: string, earliestReleaseDate: string) => {
+    const yearsDiff =
+      parseInt(selectedReleaseDate.slice(0, 4)) - parseInt(earliestReleaseDate.slice(0, 4));
+
+    return `${yearsDiff} year${yearsDiff === 1 ? '' : 's'} earlier`;
+  };
+
+  const handleUseEarlierRelease: MouseEventHandler<HTMLButtonElement> = (e) => {
+    onUseEarlierRelease(e);
+    useEarlierReleaseClicked = true;
+  };
 </script>
 
 <div class="selectedSong">
-  <img class="selectedAlbum" src={song.album.images[0].url} alt={song.name} />
-  <div class="selectedLabel">
-    <div class="selectedName">{smartquotes(song.name)}</div>
-    <div>{song.artists.map((artist) => artist.name).join(', ')}</div>
-    <div class="selectedAlbumNameAndYear">
-      <em>{smartquotes(song.album.name)}</em> &middot;{' '}
-      {song.album.release_date.slice(0, 4)}
+  <div class="selectedSongContents">
+    <img class="selectedAlbum" src={song.album.images[0].url} alt={song.name} />
+    <div class="selectedLabel">
+      <div class="selectedName">{smartquotes(song.name)}</div>
+      <div>{song.artists.map((artist) => artist.name).join(', ')}</div>
+      <div class="selectedAlbumNameAndYear">
+        <em>{smartquotes(song.album.name)}</em> &middot;{' '}
+        {song.album.release_date.slice(0, 4)}
+      </div>
     </div>
+    <button class="clearSelection" on:click={onClearSelection} aria-label="Remove selection">
+      <CloseCircleIcon />
+    </button>
   </div>
-  <button class="clearSelection" on:click={onClearSelection} aria-label="Remove selection">
-    <CloseCircleIcon />
-  </button>
+  {#await earlierRelease then earlier}
+    {#if earlier}
+      <div class="earlierReleaseBanner" transition:slide>
+        {#if earlier.id === song.id || useEarlierReleaseClicked}
+          <div class="bannerContents">
+            <CheckIcon />
+            <div class="bannerLabel">
+              <strong class="bannerTitle">This is the earliest release.</strong>
+            </div>
+          </div>
+        {:else}
+          <div class="bannerContents">
+            <HistoryIcon />
+            <div class="bannerLabel">
+              <strong class="bannerTitle">There’s an earlier release!</strong>
+              <p>
+                A version of {earlier.artists[0].name}’s
+                <strong>{earlier.name}</strong>
+                was released in <strong>{earlier.album.release_date.slice(0, 4)}</strong> on
+                <strong>{earlier.album.name}</strong>—{getYearsBefore(
+                  song.album.release_date,
+                  earlier.album.release_date
+                )}.
+              </p>
+            </div>
+          </div>
+          <button on:click={handleUseEarlierRelease}>Use earlier release</button>
+        {/if}
+      </div>
+    {/if}
+  {/await}
 </div>
 
 <style lang="scss">
   .selectedSong {
     background: var(--mauve-3);
     border-radius: var(--radius-l);
+    overflow: hidden;
+  }
+
+  .selectedSongContents {
     padding: var(--space-m);
     display: grid;
     grid-template: 'album content clear';
-    grid-template-columns: var(--space-3xl) 1fr var(--space-2xl);
-    align-items: flex-start;
+    grid-template-columns: auto 1fr var(--space-2xl);
+    align-items: center;
     gap: var(--space-m);
   }
 
   .selectedAlbum {
-    border-radius: var(--radius-xs);
-    width: var(--space-3xl);
-    height: var(--space-3xl);
+    border-radius: var(--radius-2xs);
+    width: calc(var(--space-3xl) * 2);
+    height: calc(var(--space-3xl) * 2);
+    flex-shrink: 0;
+    min-width: none;
   }
 
   .selectedLabel {
@@ -71,6 +130,43 @@
     @media (hover: hover) and (pointer: fine) {
       &:hover {
         background: var(--mauve-4);
+      }
+    }
+  }
+
+  .earlierReleaseBanner {
+    border-top: 2px solid var(--mauve-6);
+    padding: var(--space-m);
+    display: flex;
+    flex-direction: column;
+
+    .bannerContents {
+      display: flex;
+      gap: var(--space-m);
+    }
+
+    .bannerLabel {
+      flex: 1;
+    }
+
+    p {
+      font-size: var(--step--1);
+    }
+
+    button {
+      all: unset;
+      cursor: pointer;
+      text-align: center;
+      padding: var(--space-s) var(--space-m);
+      background: var(--mauve-12);
+      color: var(--mauve-1);
+      border-radius: var(--radius-s);
+      margin-block-start: var(--space-m);
+      font-weight: var(--font-weight-bold);
+
+      &:hover {
+        background: var(--violet-9);
+        color: var(--mauve-12);
       }
     }
   }

--- a/src/lib/components/SongPreview.svelte
+++ b/src/lib/components/SongPreview.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-  import { smartquotes } from '$lib/helpers';
+  import { getYearsEarlierText, smartquotes } from '$lib/helpers';
   import type { Track } from '@spotify/web-api-ts-sdk';
-  import { fade, slide } from 'svelte/transition';
+  import { slide } from 'svelte/transition';
   import CloseCircleIcon from '~icons/ri/close-circle-line';
   import HistoryIcon from '~icons/ri/history-line';
   import CheckIcon from '~icons/ri/check-line';
@@ -13,13 +13,6 @@
   export let onClearSelection: () => void;
 
   let useEarlierReleaseClicked = false;
-
-  const getYearsBefore = (selectedReleaseDate: string, earliestReleaseDate: string) => {
-    const yearsDiff =
-      parseInt(selectedReleaseDate.slice(0, 4)) - parseInt(earliestReleaseDate.slice(0, 4));
-
-    return `${yearsDiff} year${yearsDiff === 1 ? '' : 's'} earlier`;
-  };
 
   const handleUseEarlierRelease: MouseEventHandler<HTMLButtonElement> = (e) => {
     onUseEarlierRelease(e);
@@ -61,7 +54,7 @@
                 A version of {earlier.artists[0].name}’s
                 <strong>{earlier.name}</strong>
                 was released in <strong>{earlier.album.release_date.slice(0, 4)}</strong> on
-                <strong>{earlier.album.name}</strong>—{getYearsBefore(
+                <strong>{earlier.album.name}</strong>—{getYearsEarlierText(
                   song.album.release_date,
                   earlier.album.release_date
                 )}.

--- a/src/lib/components/SongSelect.svelte
+++ b/src/lib/components/SongSelect.svelte
@@ -13,16 +13,6 @@
   let discoveredEarlierRelease: Promise<Track | null> | null;
   let searchResults: Track[] | undefined = undefined;
 
-  $: sortedResults =
-    // Sort by release date ascending if original; otherwise use the default sorting
-    name === 'original'
-      ? searchResults?.sort((a, b) =>
-          parseInt(a.album.release_date.slice(0, 4)) > parseInt(b.album.release_date.slice(0, 4))
-            ? 1
-            : -1
-        )
-      : searchResults;
-
   const {
     elements: { menu, input, option, label },
     states: { open, inputValue, touchedInput, selected },
@@ -126,9 +116,9 @@
           aria-invalid={errors ? 'true' : undefined}
         />
       </label>
-      {#if $open && sortedResults}
+      {#if $open && searchResults}
         <ul use:melt={$menu} class="searchResults">
-          {#each sortedResults as track}
+          {#each searchResults as track}
             <li
               use:melt={$option({
                 value: track,

--- a/src/lib/components/SongSelect.svelte
+++ b/src/lib/components/SongSelect.svelte
@@ -4,20 +4,34 @@
   import { createCombobox, melt } from '@melt-ui/svelte';
   import ErrorMessage from './ErrorMessage.svelte';
   import SearchIcon from '~icons/ri/search-line';
+  import type { MouseEventHandler } from 'svelte/elements';
 
   export let name: string;
   export let value: Track | undefined;
   export let errors: string[] | undefined = undefined;
 
+  let discoveredEarlierRelease: Promise<Track | null> | null;
   let searchResults: Track[] | undefined = undefined;
+
+  $: sortedResults =
+    // Sort by release date ascending if original; otherwise use the default sorting
+    name === 'original'
+      ? searchResults?.sort((a, b) =>
+          parseInt(a.album.release_date.slice(0, 4)) > parseInt(b.album.release_date.slice(0, 4))
+            ? 1
+            : -1
+        )
+      : searchResults;
 
   const {
     elements: { menu, input, option, label },
     states: { open, inputValue, touchedInput, selected },
     helpers: { isSelected, isHighlighted }
   } = createCombobox<Track>({
+    preventScroll: false,
     onSelectedChange: ({ next }) => {
       if (next) {
+        checkEarliestRelease(next.value.id);
         value = next.value;
       }
       return next;
@@ -30,6 +44,19 @@
   const debounce = (callback: () => void) => {
     clearTimeout(debounceTimer);
     debounceTimer = setTimeout(callback, 250);
+  };
+
+  const checkEarliestRelease = async (id: string) => {
+    try {
+      const response = await fetch(`/api/getEarliestRelease?id=${id}`, {
+        method: 'GET'
+      });
+      discoveredEarlierRelease = await response.json();
+    } catch (error) {
+      if (error instanceof Error) {
+        console.error(error.message);
+      }
+    }
   };
 
   const search = async (query: string | undefined) => {
@@ -57,8 +84,15 @@
   };
 
   const handleClearSelection = () => {
+    discoveredEarlierRelease = null;
     inputValue.set('');
     value = undefined;
+  };
+
+  const handleUseEarlierRelease: MouseEventHandler<HTMLButtonElement> = async (e) => {
+    e.preventDefault();
+    const earlierRelease = await discoveredEarlierRelease;
+    if (earlierRelease) value = earlierRelease;
   };
 
   $: {
@@ -72,7 +106,12 @@
 
 <fieldset {name}>
   {#if value}
-    <SongPreview song={value} onClearSelection={handleClearSelection} />
+    <SongPreview
+      song={value}
+      earlierRelease={discoveredEarlierRelease}
+      onUseEarlierRelease={handleUseEarlierRelease}
+      onClearSelection={handleClearSelection}
+    />
   {:else}
     <div class="searchWrapper" class:hidden={!!value}>
       <label use:melt={$label} aria-label="Search" class="inputWrapper">
@@ -87,9 +126,9 @@
           aria-invalid={errors ? 'true' : undefined}
         />
       </label>
-      {#if $open && searchResults}
+      {#if $open && sortedResults}
         <ul use:melt={$menu} class="searchResults">
-          {#each searchResults as track}
+          {#each sortedResults as track}
             <li
               use:melt={$option({
                 value: track,
@@ -183,15 +222,16 @@
     box-shadow: 0px 10px 38px -10px rgba(22, 23, 24, 0.35),
       0px 10px 20px -15px rgba(22, 23, 24, 0.2);
     width: var(--radix-select-trigger-width);
-    padding: var(--space-xs);
+    padding: var(--space-2xs);
+    margin-block: var(--space-xs);
     z-index: 10;
-    max-height: 40vh;
+    max-height: 45vh;
   }
 
   .result {
     color: var(--mauve-12);
-    border-radius: var(--radius-s);
-    padding: var(--space-xs);
+    border-radius: var(--radius-xs);
+    padding: var(--space-2xs);
     position: relative;
     display: flex;
     align-items: center;
@@ -215,19 +255,18 @@
     display: flex;
     flex-direction: column;
     overflow: hidden;
-    gap: var(--space-s);
   }
 
   .resultAlbum {
-    width: var(--space-3xl);
-    height: var(--space-3xl);
+    width: var(--space-2xl);
+    height: var(--space-2xl);
     background: var(--mauve-3);
-    border-radius: var(--radius-xs);
+    border-radius: var(--radius-2xs);
   }
 
   .resultName {
+    font-size: var(--step--1);
     font-weight: var(--font-weight-bold);
-    margin-block-end: calc(var(--space-xs) * -1);
   }
 
   .resultName,
@@ -239,5 +278,6 @@
 
   .resultLabelDetails {
     font-size: var(--step--1);
+    color: var(--mauve-11);
   }
 </style>

--- a/src/lib/helpers.test.ts
+++ b/src/lib/helpers.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   getMaxCharacterHelpText,
   getReadableTitle,
+  getYearsEarlierText,
   removeSongExtraText,
   slugify,
   slugifyCover,
@@ -155,5 +156,23 @@ describe('smartquotes', () => {
 
   it('should convert three dots to an ellipsis', () => {
     expect(smartquotes('...Baby One More Time')).toBe('…Baby One More Time');
+  });
+});
+
+describe('getYearsEarlierText', () => {
+  it('should handle comparing two dates', () => {
+    expect(getYearsEarlierText('2000', '1960')).toBe('40 years earlier');
+  });
+
+  it('should handle one year difference', () => {
+    expect(getYearsEarlierText('2000', '1999')).toBe('1 year earlier');
+  });
+
+  it('should handle when dates are formatted differently', () => {
+    expect(getYearsEarlierText('2000', '1990-08-03')).toBe('9 years earlier');
+  });
+
+  it('should handle when less than one year', () => {
+    expect(getYearsEarlierText('2000-12-01', '2000-01-01')).toBe('earlier that year');
   });
 });

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -1,3 +1,5 @@
+import dayjs from 'dayjs';
+
 export const getMaxCharacterHelpText = (input: string, maxLength: number) => {
   if (input.length === 0) {
     return `${maxLength} characters max`;
@@ -68,4 +70,14 @@ export const smartquotes = (str: string) => {
     .replace(/"/g, '\u201d') // closing doubles
     .replace(/--/g, '\u2014') // em-dashes
     .replace(/\.\.\./g, '\u2026'); // ellipses
+};
+
+export const getYearsEarlierText = (selectedReleaseDate: string, earlierReleaseDate: string) => {
+  const afterDate = dayjs(selectedReleaseDate);
+  const beforeDate = dayjs(earlierReleaseDate);
+  const yearsDiff = afterDate.diff(beforeDate, 'year');
+
+  return yearsDiff === 0
+    ? 'earlier that year'
+    : `${yearsDiff} year${yearsDiff === 1 ? '' : 's'} earlier`;
 };

--- a/src/lib/styles/theme.css
+++ b/src/lib/styles/theme.css
@@ -110,6 +110,7 @@
   --letter-spacing-loose: 0.01em;
 
   /* Radii */
+  --radius-2xs: var(--space-2xs);
   --radius-xs: var(--space-xs);
   --radius-s: var(--space-s);
   --radius-m: var(--space-m);

--- a/src/routes/api/getEarliestRelease/+server.ts
+++ b/src/routes/api/getEarliestRelease/+server.ts
@@ -1,0 +1,31 @@
+import { SpotifyApi } from '@spotify/web-api-ts-sdk';
+import { SPOTIFY_CLIENT_ID, SPOTIFY_CLIENT_SECRET } from '$env/static/private';
+import dayjs from 'dayjs';
+import isSameOrBefore from 'dayjs/plugin/isSameOrBefore';
+
+dayjs.extend(isSameOrBefore);
+
+const spotify = SpotifyApi.withClientCredentials(SPOTIFY_CLIENT_ID, SPOTIFY_CLIENT_SECRET);
+
+// Given a Spotify track ID, returns a new Track object with the earliest release of that song
+export async function GET({ url }) {
+  const id = url.searchParams.get('id');
+
+  if (!id) return Response.json({});
+
+  const track = await spotify.tracks.get(id);
+
+  const query = `track:${track.name} artist:${
+    track.artists[0].name
+  } year:1900-${track.album.release_date.slice(0, 4)}`;
+
+  const results = (await spotify.search(query, ['track'], undefined, 5)).tracks.items;
+
+  const earliestRelease = results?.sort((a, b) =>
+    dayjs(a.album.release_date).isSameOrBefore(dayjs(b.album.release_date)) ? -1 : 1
+  )[0];
+
+  if (!earliestRelease) return Response.json({});
+
+  return Response.json(earliestRelease);
+}


### PR DESCRIPTION
- Check song submissions for earlier releases by the same artist
- Prompt the user to select an earlier release if one exists
- Validate that the selected song is the earliest and display a message if so
- Condense song selection dropdown to display more options
- Add transition to song selection dropdown
- Resolves #10 

https://github.com/evadecker/genderswap.fm/assets/4117920/ca11b3be-e299-4560-9677-faf5aa5d2082