### PR TITLE
fix: Clarify earliest release copy

### DIFF
--- a/src/lib/components/SongPreview.svelte
+++ b/src/lib/components/SongPreview.svelte
@@ -42,7 +42,7 @@
           <div class="bannerContents">
             <CheckIcon />
             <div class="bannerLabel">
-              <strong class="bannerTitle">This is the earliest release.</strong>
+              <strong class="bannerTitle">This is the earliest release we could find.</strong>
             </div>
           </div>
         {:else}


### PR DESCRIPTION
- "This is the earliest release _we could find._"