### PR TITLE
feat: View 48 songs per page

### DIFF
--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -7,7 +7,7 @@ type GridItem = {
   slug: string;
 };
 
-const PAGE_SIZE = 40;
+const PAGE_SIZE = 48;
 
 export async function load({ url }) {
   const page = Number(url.searchParams.get('page') ?? 1);


### PR DESCRIPTION
- Increase from 40 to 48 for even number of grid items when there are 3 columns