### PR TITLE
feat: Make album art radius consistent, order OG tags

### DIFF
--- a/src/lib/components/CoverCard.svelte
+++ b/src/lib/components/CoverCard.svelte
@@ -85,7 +85,7 @@
 
   .album {
     background-color: var(--mauve-4);
-    border-radius: var(--radius-xs);
+    border-radius: var(--radius-album);
     overflow: hidden;
     aspect-ratio: 1;
     transition: transform 0.2s ease-in-out;

--- a/src/lib/components/CoverComparison.svelte
+++ b/src/lib/components/CoverComparison.svelte
@@ -141,7 +141,7 @@
     aspect-ratio: 1 / 1;
     background: var(--mauve-3);
     overflow: hidden;
-    border-radius: var(--radius-s);
+    border-radius: var(--radius-album);
     position: relative;
     z-index: 1;
     box-shadow: 0px 1.7px 2.2px rgba(0, 0, 0, 0.02), 0px 4px 5.3px rgba(0, 0, 0, 0.028),

--- a/src/lib/components/SongPreview.svelte
+++ b/src/lib/components/SongPreview.svelte
@@ -95,7 +95,7 @@
   }
 
   .selectedAlbum {
-    border-radius: var(--radius-2xs);
+    border-radius: var(--radius-album);
     width: calc(var(--space-3xl) * 2);
     height: calc(var(--space-3xl) * 2);
     flex-shrink: 0;

--- a/src/lib/components/SongSelect.svelte
+++ b/src/lib/components/SongSelect.svelte
@@ -257,7 +257,7 @@
     width: var(--space-2xl);
     height: var(--space-2xl);
     background: var(--mauve-3);
-    border-radius: var(--radius-2xs);
+    border-radius: var(--radius-album);
   }
 
   .resultName {

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -116,3 +116,18 @@ export const TAGS: Record<Enums<'tags'>, Tag> = {
     description: 'These covers were released over 50 years after the original.'
   }
 };
+
+export const ORDERED_TAG_GROUPS: Enums<'tags'>[][] = [
+  ['transition_mtf', 'transition_ftm'],
+  ['valence_up', 'valence_down'],
+  ['tempo_up', 'tempo_down'],
+  ['duration_up', 'duration_down'],
+  ['key_change'],
+  ['time_signature_change'],
+  ['energy_up', 'energy_down'],
+  ['acousticness_up', 'acousticness_down'],
+  ['danceability_up', 'danceability_down'],
+  ['instrumentalness_up', 'instrumentalness_down'],
+  ['years_apart_10', 'years_apart_20', 'years_apart_30', 'years_apart_40', 'years_apart_50'],
+  ['transition_mtm', 'transition_ftf']
+];

--- a/src/lib/styles/theme.css
+++ b/src/lib/styles/theme.css
@@ -116,6 +116,7 @@
   --radius-m: var(--space-m);
   --radius-l: var(--space-l);
   --radius-full: 9999px;
+  --radius-album: max(3px, 1%);
 
   /* Font weights */
   --font-weight-normal: 400;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2,7 +2,7 @@
   import { page } from '$app/stores';
   import CoverCard from '$lib/components/CoverCard.svelte';
   import { goto } from '$app/navigation';
-  import { TAGS } from '$lib/constants.js';
+  import { TAGS, ORDERED_TAG_GROUPS } from '$lib/constants.js';
   import type { Enums } from '$lib/types/types.js';
   import SearchIcon from '~icons/ri/search-line';
   import CloseCircleIcon from '~icons/ri/close-circle-fill';
@@ -23,21 +23,6 @@
   }
   $: currentPage = Number($page.url.searchParams.get('page')) || 1;
   $: currentTag = $page.url.searchParams.get('tag') as Enums<'tags'> | null;
-
-  const tagGroups: Enums<'tags'>[][] = [
-    ['transition_mtf', 'transition_ftm'],
-    ['valence_up', 'valence_down'],
-    ['tempo_up', 'tempo_down'],
-    ['duration_up', 'duration_down'],
-    ['key_change'],
-    ['time_signature_change'],
-    ['energy_up', 'energy_down'],
-    ['acousticness_up', 'acousticness_down'],
-    ['danceability_up', 'danceability_down'],
-    ['instrumentalness_up', 'instrumentalness_down'],
-    ['years_apart_10', 'years_apart_20', 'years_apart_30', 'years_apart_40', 'years_apart_50'],
-    ['transition_mtm', 'transition_ftf']
-  ];
 
   let debounceTimer: ReturnType<typeof setTimeout>;
   const debounce = (callback: () => void) => {
@@ -159,7 +144,7 @@
     {/if}
   </div>
   <div class="tags">
-    {#each tagGroups as tagGroup}
+    {#each ORDERED_TAG_GROUPS as tagGroup}
       <div class="tag-group">
         {#each tagGroup as tag}
           <button

--- a/src/routes/cover/[slug]/og.png/+server.ts
+++ b/src/routes/cover/[slug]/og.png/+server.ts
@@ -3,7 +3,7 @@ import sharp from 'sharp';
 import { supabase } from '$lib/supabase';
 import { getReadableTitle } from '$lib/helpers';
 import type { Cover } from '../+page.server';
-import { TAGS } from '$lib/constants';
+import { TAGS, ORDERED_TAG_GROUPS } from '$lib/constants';
 
 export async function GET({ params, url }) {
   const { slug } = params;
@@ -38,7 +38,10 @@ export async function GET({ params, url }) {
         })
       : 'A cover on Genderswap.fm';
 
-  const displayTags = tags.slice(0, 4).map((tag) => TAGS[tag].label);
+  const orderedTags = tags.sort(
+    (a, b) => ORDERED_TAG_GROUPS.flat().indexOf(a) - ORDERED_TAG_GROUPS.flat().indexOf(b)
+  );
+  const displayTags = orderedTags.slice(0, 4).map((tag) => TAGS[tag].label);
   tags.length > 4 ? displayTags.push(`+${tags.length - 4}`) : null;
 
   const albumBoxShadow =
@@ -119,7 +122,7 @@ export async function GET({ params, url }) {
                         width: '340',
                         height: '340',
                         style: {
-                          borderRadius: '8px',
+                          borderRadius: '6px',
                           boxShadow: albumBoxShadow,
                           objectFit: 'cover',
                           transform: 'rotate(-6deg) scale(0.9) translateX(132px) translateY(-16px)'
@@ -169,7 +172,7 @@ export async function GET({ params, url }) {
                       style: {
                         backgroundColor: '#F2EFF3',
                         padding: '6px 16px 9px 16px',
-                        borderRadius: '40px',
+                        borderRadius: '12px',
                         fontSize: '28px',
                         lineHeight: 1.2,
                         color: '#65636D'


### PR DESCRIPTION
- Add a new theme variable for `—radius-album` which is set to `1%` of the album width, or `3px`, whichever is larger; this prevents strange visuals when album art includes a square border while maintaining a small bit of roundness. The smaller percentage is also closer to what the roundness on a real-life album cover would be
- Apply to all album art
- Reorder tags on generated OG images to be in the same order as the homepage (MTF/FTM first, then valence, etc.)

<img width="225" alt="image" src="https://github.com/evadecker/genderswap.fm/assets/4117920/f31cc450-ce49-4bc2-8f1e-0ee424d2d0c0">

<img width="233" alt="image" src="https://github.com/evadecker/genderswap.fm/assets/4117920/5908f620-49b0-4726-92af-8fc2107e9b8c">
