### PR TITLE
feat: Sort tags on detail page

### DIFF
--- a/src/lib/helpers.test.ts
+++ b/src/lib/helpers.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   getMaxCharacterHelpText,
   getReadableTitle,
+  getSortedTags,
   getYearsEarlierText,
   removeSongExtraText,
   slugify,
@@ -174,5 +175,42 @@ describe('getYearsEarlierText', () => {
 
   it('should handle when less than one year', () => {
     expect(getYearsEarlierText('2000-12-01', '2000-01-01')).toBe('earlier that year');
+  });
+});
+
+describe('getSortedTags', () => {
+  it('should correctly order tags', () => {
+    expect(
+      getSortedTags([
+        'acousticness_up',
+        'danceability_down',
+        'duration_down',
+        'energy_down',
+        'instrumentalness_up',
+        'key_change',
+        'tempo_up',
+        'time_signature_change',
+        'transition_mtf',
+        // Two transition_ tags would never appear together,
+        // But MTM and FTF should always appear at the end
+        // So we need to test both
+        'transition_mtm',
+        'valence_down',
+        'years_apart_10'
+      ])
+    ).toEqual([
+      'transition_mtf', // MTF and FTM first
+      'valence_down', // Valence second
+      'tempo_up', // Tempo third
+      'duration_down', // Duration fourth
+      'key_change', // Key change fifth
+      'time_signature_change', // Time signature change sixth
+      'energy_down', // Energy seventh
+      'acousticness_up', // Acousticness eighth
+      'danceability_down', // Danceability ninth
+      'instrumentalness_up', // Instrumentalness tenth
+      'years_apart_10', // Years apart eleventh
+      'transition_mtm' // MTM and FTF last
+    ]);
   });
 });

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -1,4 +1,6 @@
 import dayjs from 'dayjs';
+import { ORDERED_TAG_GROUPS } from './constants';
+import type { Enums } from './types/types';
 
 export const getMaxCharacterHelpText = (input: string, maxLength: number) => {
   if (input.length === 0) {
@@ -80,4 +82,10 @@ export const getYearsEarlierText = (selectedReleaseDate: string, earlierReleaseD
   return yearsDiff === 0
     ? 'earlier that year'
     : `${yearsDiff} year${yearsDiff === 1 ? '' : 's'} earlier`;
+};
+
+export const getSortedTags = (tags: Enums<'tags'>[]) => {
+  return tags.sort(
+    (a, b) => ORDERED_TAG_GROUPS.flat().indexOf(a) - ORDERED_TAG_GROUPS.flat().indexOf(b)
+  );
 };

--- a/src/routes/cover/[slug]/+page.svelte
+++ b/src/routes/cover/[slug]/+page.svelte
@@ -7,8 +7,10 @@
   import { page } from '$app/stores';
   import { onMount } from 'svelte';
   import confetti from 'canvas-confetti';
+  import { getSortedTags } from '$lib/helpers.js';
 
   export let data;
+
   const isNew = $page.url.searchParams.get('new') === 'true' ? true : false;
 
   const formattedDate = dayjs(data.created_at).format('MMMM D, YYYY');
@@ -107,7 +109,7 @@
   {/if}
   {#if data.tags}
     <TagCloud>
-      {#each data.tags as tag}
+      {#each getSortedTags(data.tags) as tag}
         <Tag text={TAGS[tag].label} url={`/?tag=${tag}`} />
       {/each}
     </TagCloud>

--- a/src/routes/cover/[slug]/og.png/+server.ts
+++ b/src/routes/cover/[slug]/og.png/+server.ts
@@ -1,7 +1,7 @@
 import satori from 'satori';
 import sharp from 'sharp';
 import { supabase } from '$lib/supabase';
-import { getReadableTitle } from '$lib/helpers';
+import { getReadableTitle, getSortedTags } from '$lib/helpers';
 import type { Cover } from '../+page.server';
 import { TAGS, ORDERED_TAG_GROUPS } from '$lib/constants';
 
@@ -38,10 +38,9 @@ export async function GET({ params, url }) {
         })
       : 'A cover on Genderswap.fm';
 
-  const orderedTags = tags.sort(
-    (a, b) => ORDERED_TAG_GROUPS.flat().indexOf(a) - ORDERED_TAG_GROUPS.flat().indexOf(b)
-  );
-  const displayTags = orderedTags.slice(0, 4).map((tag) => TAGS[tag].label);
+  const displayTags = getSortedTags(tags)
+    .slice(0, 4)
+    .map((tag) => TAGS[tag].label);
   tags.length > 4 ? displayTags.push(`+${tags.length - 4}`) : null;
 
   const albumBoxShadow =


### PR DESCRIPTION
- Make tag sorting match on the homepage, detail page, and open graph images
- Abstract a new helper function, `getSortedTags()`
- Write a test