### PR TITLE
feat: Use `tsparticles` confetti instead of `canvas-confetti`

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "genderswap.fm",
   "version": "0.0.1",
   "private": true,
+  "type": "module",
   "scripts": {
     "dev": "vite dev",
     "build": "vite build",
@@ -14,6 +15,19 @@
     "test:integration": "playwright test",
     "test:unit": "vitest",
     "dbtypegen": "supabase gen types typescript --project-id qbmycnemttkukygnvmbu > src/types/db-generated.types.ts"
+  },
+  "dependencies": {
+    "@radix-ui/colors": "^3.0.0",
+    "@spotify/web-api-ts-sdk": "^1.1.2",
+    "@supabase/supabase-js": "^2.38.4",
+    "@types/canvas-confetti": "^1.6.3",
+    "@vercel/analytics": "^1.1.1",
+    "dayjs": "^1.11.10",
+    "satori": "^0.10.9",
+    "sharp": "^0.32.6",
+    "svelte-autosize": "^1.1.0",
+    "svelte-preprocess": "^5.1.0",
+    "tsparticles-confetti": "^2.12.0"
   },
   "devDependencies": {
     "@iconify-json/ri": "^1.1.12",
@@ -43,19 +57,5 @@
     "vite": "^4.5.0",
     "vitest": "^0.32.4",
     "zod": "^3.22.4"
-  },
-  "type": "module",
-  "dependencies": {
-    "@radix-ui/colors": "^3.0.0",
-    "@spotify/web-api-ts-sdk": "^1.1.2",
-    "@supabase/supabase-js": "^2.38.4",
-    "@types/canvas-confetti": "^1.6.3",
-    "@vercel/analytics": "^1.1.1",
-    "canvas-confetti": "^1.9.1",
-    "dayjs": "^1.11.10",
-    "satori": "^0.10.9",
-    "sharp": "^0.32.6",
-    "svelte-autosize": "^1.1.0",
-    "svelte-preprocess": "^5.1.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,9 +20,6 @@ dependencies:
   '@vercel/analytics':
     specifier: ^1.1.1
     version: 1.1.1
-  canvas-confetti:
-    specifier: ^1.9.1
-    version: 1.9.1
   dayjs:
     specifier: ^1.11.10
     version: 1.11.10
@@ -38,6 +35,9 @@ dependencies:
   svelte-preprocess:
     specifier: ^5.1.0
     version: 5.1.0(postcss@8.4.31)(sass@1.69.5)(svelte@4.2.5)(typescript@5.2.2)
+  tsparticles-confetti:
+    specifier: ^2.12.0
+    version: 2.12.0
 
 devDependencies:
   '@iconify-json/ri':
@@ -1191,10 +1191,6 @@ packages:
 
   /camelize@1.0.1:
     resolution: {integrity: sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==}
-    dev: false
-
-  /canvas-confetti@1.9.1:
-    resolution: {integrity: sha512-jieDCn9OnPgFu5q+rbOGUmIGOjzgOnecW1/6KH07kAFAMwOczcTc4clde9pdyUPIAd/2wxZ8C5u7mBAcOpGK8Q==}
     dev: false
 
   /chai@4.3.10:
@@ -3221,6 +3217,164 @@ packages:
   /tslib@2.6.2:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
     dev: true
+
+  /tsparticles-basic@2.12.0:
+    resolution: {integrity: sha512-pN6FBpL0UsIUXjYbiui5+IVsbIItbQGOlwyGV55g6IYJBgdTNXgFX0HRYZGE9ZZ9psEXqzqwLM37zvWnb5AG9g==}
+    dependencies:
+      tsparticles-engine: 2.12.0
+      tsparticles-move-base: 2.12.0
+      tsparticles-shape-circle: 2.12.0
+      tsparticles-updater-color: 2.12.0
+      tsparticles-updater-opacity: 2.12.0
+      tsparticles-updater-out-modes: 2.12.0
+      tsparticles-updater-size: 2.12.0
+    dev: false
+
+  /tsparticles-confetti@2.12.0:
+    resolution: {integrity: sha512-PsxBL1DjYNNZecFFcymivnPypuxHKh0ePz2/9CctKl6zwS+Z8cHBCoszg8jBx6PJDJkAxIa76taezd54caISYg==}
+    dependencies:
+      tsparticles-basic: 2.12.0
+      tsparticles-engine: 2.12.0
+      tsparticles-plugin-emitters: 2.12.0
+      tsparticles-plugin-motion: 2.12.0
+      tsparticles-shape-cards: 2.12.0
+      tsparticles-shape-heart: 2.12.0
+      tsparticles-shape-image: 2.12.0
+      tsparticles-shape-polygon: 2.12.0
+      tsparticles-shape-square: 2.12.0
+      tsparticles-shape-star: 2.12.0
+      tsparticles-shape-text: 2.12.0
+      tsparticles-updater-life: 2.12.0
+      tsparticles-updater-roll: 2.12.0
+      tsparticles-updater-rotate: 2.12.0
+      tsparticles-updater-tilt: 2.12.0
+      tsparticles-updater-wobble: 2.12.0
+    dev: false
+
+  /tsparticles-engine@2.12.0:
+    resolution: {integrity: sha512-ZjDIYex6jBJ4iMc9+z0uPe7SgBnmb6l+EJm83MPIsOny9lPpetMsnw/8YJ3xdxn8hV+S3myTpTN1CkOVmFv0QQ==}
+    requiresBuild: true
+    dev: false
+
+  /tsparticles-move-base@2.12.0:
+    resolution: {integrity: sha512-oSogCDougIImq+iRtIFJD0YFArlorSi8IW3HD2gO3USkH+aNn3ZqZNTqp321uB08K34HpS263DTbhLHa/D6BWw==}
+    dependencies:
+      tsparticles-engine: 2.12.0
+    dev: false
+
+  /tsparticles-plugin-emitters@2.12.0:
+    resolution: {integrity: sha512-fbskYnaXWXivBh9KFReVCfqHdhbNQSK2T+fq2qcGEWpwtDdgujcaS1k2Q/xjZnWNMfVesik4IrqspcL51gNdSA==}
+    dependencies:
+      tsparticles-engine: 2.12.0
+    dev: false
+
+  /tsparticles-plugin-motion@2.12.0:
+    resolution: {integrity: sha512-VeS0VDV5wc9a4t0xkPi3lkHqOvKRlELq4mEEvaIk8WwgOcx05TUZcJIIbhftnNabqgpHrZ4iUP5Nb2wZ3DBwWQ==}
+    dependencies:
+      tsparticles-engine: 2.12.0
+    dev: false
+
+  /tsparticles-shape-cards@2.12.0:
+    resolution: {integrity: sha512-4mSV1C7c/7SsSbS4A5HJEZE5tB2fOAEUXm52uagzBVMbL/YI+XkjOpi7L6JtCNcBKrWnZ/IgnnLMyyFGhNc4pA==}
+    dependencies:
+      tsparticles-engine: 2.12.0
+    dev: false
+
+  /tsparticles-shape-circle@2.12.0:
+    resolution: {integrity: sha512-L6OngbAlbadG7b783x16ns3+SZ7i0SSB66M8xGa5/k+YcY7zm8zG0uPt1Hd+xQDR2aNA3RngVM10O23/Lwk65Q==}
+    dependencies:
+      tsparticles-engine: 2.12.0
+    dev: false
+
+  /tsparticles-shape-heart@2.12.0:
+    resolution: {integrity: sha512-OK8CJrCY0Z6YAedyfTQh52u7KsurkP8eLNWDW11BhqcvDQkfwJC5g25Y3VrcW9Rwc88hrbNwFQlsKbY6tOn7qA==}
+    dependencies:
+      tsparticles-engine: 2.12.0
+    dev: false
+
+  /tsparticles-shape-image@2.12.0:
+    resolution: {integrity: sha512-iCkSdUVa40DxhkkYjYuYHr9MJGVw+QnQuN5UC+e/yBgJQY+1tQL8UH0+YU/h0GHTzh5Sm+y+g51gOFxHt1dj7Q==}
+    dependencies:
+      tsparticles-engine: 2.12.0
+    dev: false
+
+  /tsparticles-shape-polygon@2.12.0:
+    resolution: {integrity: sha512-5YEy7HVMt1Obxd/jnlsjajchAlYMr9eRZWN+lSjcFSH6Ibra7h59YuJVnwxOxAobpijGxsNiBX0PuGQnB47pmA==}
+    dependencies:
+      tsparticles-engine: 2.12.0
+    dev: false
+
+  /tsparticles-shape-square@2.12.0:
+    resolution: {integrity: sha512-33vfajHqmlODKaUzyPI/aVhnAOT09V7nfEPNl8DD0cfiNikEuPkbFqgJezJuE55ebtVo7BZPDA9o7GYbWxQNuw==}
+    dependencies:
+      tsparticles-engine: 2.12.0
+    dev: false
+
+  /tsparticles-shape-star@2.12.0:
+    resolution: {integrity: sha512-4sfG/BBqm2qBnPLASl2L5aBfCx86cmZLXeh49Un+TIR1F5Qh4XUFsahgVOG0vkZQa+rOsZPEH04xY5feWmj90g==}
+    dependencies:
+      tsparticles-engine: 2.12.0
+    dev: false
+
+  /tsparticles-shape-text@2.12.0:
+    resolution: {integrity: sha512-v2/FCA+hyTbDqp2ymFOe97h/NFb2eezECMrdirHWew3E3qlvj9S/xBibjbpZva2gnXcasBwxn0+LxKbgGdP0rA==}
+    dependencies:
+      tsparticles-engine: 2.12.0
+    dev: false
+
+  /tsparticles-updater-color@2.12.0:
+    resolution: {integrity: sha512-KcG3a8zd0f8CTiOrylXGChBrjhKcchvDJjx9sp5qpwQK61JlNojNCU35xoaSk2eEHeOvFjh0o3CXWUmYPUcBTQ==}
+    dependencies:
+      tsparticles-engine: 2.12.0
+    dev: false
+
+  /tsparticles-updater-life@2.12.0:
+    resolution: {integrity: sha512-J7RWGHAZkowBHpcLpmjKsxwnZZJ94oGEL2w+wvW1/+ZLmAiFFF6UgU0rHMC5CbHJT4IPx9cbkYMEHsBkcRJ0Bw==}
+    dependencies:
+      tsparticles-engine: 2.12.0
+    dev: false
+
+  /tsparticles-updater-opacity@2.12.0:
+    resolution: {integrity: sha512-YUjMsgHdaYi4HN89LLogboYcCi1o9VGo21upoqxq19yRy0hRCtx2NhH22iHF/i5WrX6jqshN0iuiiNefC53CsA==}
+    dependencies:
+      tsparticles-engine: 2.12.0
+    dev: false
+
+  /tsparticles-updater-out-modes@2.12.0:
+    resolution: {integrity: sha512-owBp4Gk0JNlSrmp12XVEeBroDhLZU+Uq3szbWlHGSfcR88W4c/0bt0FiH5bHUqORIkw+m8O56hCjbqwj69kpOQ==}
+    dependencies:
+      tsparticles-engine: 2.12.0
+    dev: false
+
+  /tsparticles-updater-roll@2.12.0:
+    resolution: {integrity: sha512-dxoxY5jP4C9x15BxlUv5/Q8OjUPBiE09ToXRyBxea9aEJ7/iMw6odvi1HuT0H1vTIfV7o1MYawjeCbMycvODKQ==}
+    dependencies:
+      tsparticles-engine: 2.12.0
+    dev: false
+
+  /tsparticles-updater-rotate@2.12.0:
+    resolution: {integrity: sha512-waOFlGFmEZOzsQg4C4VSejNVXGf4dMf3fsnQrEROASGf1FCd8B6WcZau7JtXSTFw0OUGuk8UGz36ETWN72DkCw==}
+    dependencies:
+      tsparticles-engine: 2.12.0
+    dev: false
+
+  /tsparticles-updater-size@2.12.0:
+    resolution: {integrity: sha512-B0yRdEDd/qZXCGDL/ussHfx5YJ9UhTqNvmS5X2rR2hiZhBAE2fmsXLeWkdtF2QusjPeEqFDxrkGiLOsh6poqRA==}
+    dependencies:
+      tsparticles-engine: 2.12.0
+    dev: false
+
+  /tsparticles-updater-tilt@2.12.0:
+    resolution: {integrity: sha512-HDEFLXazE+Zw+kkKKAiv0Fs9D9sRP61DoCR6jZ36ipea6OBgY7V1Tifz2TSR1zoQkk57ER9+EOQbkSQO+YIPGQ==}
+    dependencies:
+      tsparticles-engine: 2.12.0
+    dev: false
+
+  /tsparticles-updater-wobble@2.12.0:
+    resolution: {integrity: sha512-85FIRl95ipD3jfIsQdDzcUC5PRMWIrCYqBq69nIy9P8rsNzygn+JK2n+P1VQZowWsZvk0mYjqb9OVQB21Lhf6Q==}
+    dependencies:
+      tsparticles-engine: 2.12.0
+    dev: false
 
   /tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}

--- a/src/lib/components/Sparkle.svelte
+++ b/src/lib/components/Sparkle.svelte
@@ -68,13 +68,15 @@
     width: var(--sparkle-size);
     height: var(--sparkle-size);
     pointer-events: none;
-    animation: 1s grow-and-shrink ease-in-out forwards;
+    animation: 1s grow-and-shrink ease-in-out both;
+    animation-delay: 0.4s;
     color: hotpink;
   }
 
   .sparkle-lines {
     position: absolute;
     animation: 1s spin cubic-bezier(0.21, 0.87, 0.85, 0.1) both;
+    animation-delay: 0.4s;
   }
 
   svg {
@@ -86,9 +88,11 @@
 
   .vertical {
     animation: 1s scaleY ease-in-out both;
+    animation-delay: 0.4s;
   }
 
   .horizontal {
     animation: 1s scaleX ease-in-out both;
+    animation-delay: 0.4s;
   }
 </style>

--- a/src/routes/cover/[slug]/+page.svelte
+++ b/src/routes/cover/[slug]/+page.svelte
@@ -9,6 +9,7 @@
   import { confetti } from 'tsparticles-confetti';
   import { getSortedTags } from '$lib/helpers.js';
   import Sparkle from '$lib/components/Sparkle.svelte';
+  import type { IConfettiOptions } from 'tsparticles-confetti/types/IConfettiOptions.js';
 
   export let data;
 
@@ -20,7 +21,7 @@
     const fireConfetti = (placement: 'left' | 'right' | 'bottom') => {
       const center = 90;
 
-      const sharedProps = {
+      const sharedProps: Partial<IConfettiOptions> = {
         scalar: 1.8,
         colors: ['#ff69b4'],
         shapes: ['square'],
@@ -29,7 +30,7 @@
         disableForReducedMotion: true
       };
 
-      const directionalProps = {
+      const directionalProps: Record<'left' | 'right' | 'bottom', Partial<IConfettiOptions>> = {
         left: {
           count: 40,
           startVelocity: 80,

--- a/src/routes/cover/[slug]/+page.svelte
+++ b/src/routes/cover/[slug]/+page.svelte
@@ -6,7 +6,7 @@
   import { TAGS } from '$lib/constants';
   import { page } from '$app/stores';
   import { onMount } from 'svelte';
-  import confetti from 'canvas-confetti';
+  import { confetti } from 'tsparticles-confetti';
   import { getSortedTags } from '$lib/helpers.js';
   import Sparkle from '$lib/components/Sparkle.svelte';
 
@@ -18,40 +18,35 @@
 
   onMount(async () => {
     const fireConfetti = (placement: 'left' | 'right' | 'bottom') => {
-      // @ts-ignore
-      const confettiShape = confetti.shapeFromPath({
-        path: 'M0 2.51004C1.39 1.80004 2.85 1.22004 4.35 0.760044C5.88 0.430044 7.43 0.230044 9 0.170044C10.55 0.230044 12.11 0.430044 13.63 0.760044C15.13 1.21004 16.6 1.80004 18 2.51004C18 5.17004 18 7.83004 18 10.49C16.58 9.77004 15.14 9.20004 13.64 8.74004C12.11 8.41004 10.55 8.21004 8.98 8.15004C7.42 8.21004 5.88 8.42004 4.35 8.75004C2.84 9.21004 1.39 9.79004 0 10.51C0 7.83004 0 5.17004 0 2.51004Z'
-      });
-      // https://www.flagcolorcodes.com/transgender
-      const colors = ['#ffffff', '#5BCEFA', '#00a4b8', '#007290', '#F5A9B8', '#fc5cdb', '#eb29da'];
       const center = 90;
 
       const sharedProps = {
-        ticks: 300,
-        shapes: [confettiShape],
-        colors,
-        disableForReducedMotion: true,
-        zIndex: 999
+        scalar: 1.8,
+        colors: ['#ff69b4'],
+        shapes: ['square'],
+        gravity: 2,
+        ticks: 30,
+        disableForReducedMotion: true
       };
 
       const directionalProps = {
         left: {
-          particleCount: 20,
-          startVelocity: 45,
-          angle: center - 15,
+          count: 40,
+          startVelocity: 80,
+          angle: center - 40,
           origin: { x: 0, y: 1 },
           drift: 0.5
         },
         right: {
-          particleCount: 20,
-          startVelocity: 45,
-          angle: center + 15,
+          count: 40,
+          startVelocity: 80,
+          angle: center + 40,
           origin: { x: 1, y: 1 },
           drift: -0.5
         },
         bottom: {
-          particleCount: 80,
-          startVelocity: 80,
+          count: 100,
+          startVelocity: 100,
           angle: center,
           origin: { x: 0.5, y: 1 },
           drift: 0
@@ -62,32 +57,14 @@
       confetti({
         ...sharedProps,
         ...directionalProps[placement],
-        spread: placement === 'bottom' ? 30 : 20,
-        decay: 0.92
-      });
-
-      // A weaker last of confetti with a larger spread
-      confetti({
-        ...sharedProps,
-        ...directionalProps[placement],
-        spread: placement === 'bottom' ? 50 : 40,
-        decay: 0.9
-      });
-
-      // The weakest blast of confetti
-      confetti({
-        ...sharedProps,
-        ...directionalProps[placement],
-        spread: placement === 'bottom' ? 90 : 80,
-        decay: 0.89,
-        startVelocity: 30
+        spread: placement === 'bottom' ? 30 : 10
       });
     };
 
     if (isNew) {
       setTimeout(() => fireConfetti('left'), 1000);
-      setTimeout(() => fireConfetti('right'), 1400);
-      setTimeout(() => fireConfetti('bottom'), 2800);
+      setTimeout(() => fireConfetti('right'), 1600);
+      setTimeout(() => fireConfetti('bottom'), 3000);
     }
   });
 </script>


### PR DESCRIPTION
- `canvas-confetti` doesn't support high DPI displays
- `tsparticles` uses the exact same API with support for retina displays and more fluid animations 🎉 
- Make all the confetti BIG and PINK
- Modify the angle and timing of confetti
- Use TypeScript typings for objects

https://github.com/evadecker/genderswap.fm/assets/4117920/d80f5d07-79c1-4336-8ffc-5feb86349c9f