### PR TITLE
fix: Unhandled Promise rejection and `getEarliestRelease` failures

### DIFF
--- a/src/lib/components/SongPreview.svelte
+++ b/src/lib/components/SongPreview.svelte
@@ -8,7 +8,7 @@
   import type { MouseEventHandler } from 'svelte/elements';
 
   export let song: Track;
-  export let earlierRelease: Promise<Track | null> | null = null;
+  export let earlierRelease: Track | null;
   export let onUseEarlierRelease: () => void;
   export let onClearSelection: () => void;
 
@@ -42,40 +42,39 @@
       <CloseCircleIcon />
     </button>
   </div>
-  {#await earlierRelease then earlier}
-    {#if earlier && !wasKeepThisReleaseClicked}
-      <div class="earlierReleaseBanner" transition:slide>
-        {#if earlier.id === song.id || wasEarlierReleaseClicked}
-          <div class="bannerContents">
-            <CheckIcon />
-            <div class="bannerLabel">
-              <strong class="bannerTitle">Earliest release available on Spotify</strong>
-            </div>
+
+  {#if earlierRelease && !wasKeepThisReleaseClicked}
+    <div class="earlierReleaseBanner" transition:slide>
+      {#if earlierRelease.id === song.id || wasEarlierReleaseClicked}
+        <div class="bannerContents">
+          <CheckIcon />
+          <div class="bannerLabel">
+            <strong class="bannerTitle">Earliest release available on Spotify</strong>
           </div>
-        {:else}
-          <div class="bannerContents">
-            <HistoryIcon />
-            <div class="bannerLabel">
-              <strong class="bannerTitle">There’s an earlier release!</strong>
-              <p>
-                A version of {earlier.artists[0].name}’s
-                <strong>{earlier.name}</strong>
-                was released {getYearsEarlierText(
-                  song.album.release_date,
-                  earlier.album.release_date
-                )} in <strong>{earlier.album.release_date.slice(0, 4)}</strong> on the album
-                <strong>{earlier.album.name}</strong>.
-              </p>
-            </div>
+        </div>
+      {:else if earlierRelease.id !== song.id}
+        <div class="bannerContents">
+          <HistoryIcon />
+          <div class="bannerLabel">
+            <strong class="bannerTitle">There’s an earlier release!</strong>
+            <p>
+              A version of {earlierRelease.artists[0].name}’s
+              <strong>{earlierRelease.name}</strong>
+              was released {getYearsEarlierText(
+                song.album.release_date,
+                earlierRelease.album.release_date
+              )} in <strong>{earlierRelease.album.release_date.slice(0, 4)}</strong> on the album
+              <strong>{earlierRelease.album.name}</strong>.
+            </p>
           </div>
-          <div class="bannerActions">
-            <button on:click={handleKeepThisRelease} class="secondary">Keep newer release</button>
-            <button on:click={handleUseEarlierRelease} class="primary">Use earlier release</button>
-          </div>
-        {/if}
-      </div>
-    {/if}
-  {/await}
+        </div>
+        <div class="bannerActions">
+          <button on:click={handleKeepThisRelease} class="secondary">Keep this release</button>
+          <button on:click={handleUseEarlierRelease} class="primary">Use earlier release</button>
+        </div>
+      {/if}
+    </div>
+  {/if}
 </div>
 
 <style lang="scss">

--- a/src/lib/helpers.test.ts
+++ b/src/lib/helpers.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import {
+  encodeSearchQuery,
   getMaxCharacterHelpText,
   getReadableTitle,
   getSortedTags,
@@ -212,5 +213,17 @@ describe('getSortedTags', () => {
       'years_apart_10', // Years apart eleventh
       'transition_mtm' // MTM and FTF last
     ]);
+  });
+});
+
+describe('encodeSearchQuery', () => {
+  it('should encode forward slashes', () => {
+    expect(encodeSearchQuery('trying/failing')).toBe('trying-failing');
+  });
+
+  it('should remove question marks', () => {
+    expect(encodeSearchQuery("why'd you only call me when you're high?")).toBe(
+      'why%27d%20you%20only%20call%20me%20when%20you%27re%20high'
+    );
   });
 });

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -89,3 +89,11 @@ export const getSortedTags = (tags: Enums<'tags'>[]) => {
     (a, b) => ORDERED_TAG_GROUPS.flat().indexOf(a) - ORDERED_TAG_GROUPS.flat().indexOf(b)
   );
 };
+
+export const encodeSearchQuery = (query: string) => {
+  return encodeURIComponent(
+    query
+      .replace(/\//g, '-') // Replace all forward slashes with dashes
+      .replace(/\?/g, '') // Remove question marks
+  ).replace(/'/g, '%27'); // Replace all single quotes with %27;
+};

--- a/src/routes/api/getEarliestRelease/+server.ts
+++ b/src/routes/api/getEarliestRelease/+server.ts
@@ -2,6 +2,7 @@ import { SpotifyApi } from '@spotify/web-api-ts-sdk';
 import { SPOTIFY_CLIENT_ID, SPOTIFY_CLIENT_SECRET } from '$env/static/private';
 import dayjs from 'dayjs';
 import isSameOrBefore from 'dayjs/plugin/isSameOrBefore';
+import { encodeSearchQuery, removeSongExtraText } from '$lib/helpers';
 
 dayjs.extend(isSameOrBefore);
 
@@ -9,19 +10,42 @@ const spotify = SpotifyApi.withClientCredentials(SPOTIFY_CLIENT_ID, SPOTIFY_CLIE
 
 // Given a Spotify track ID, returns a new Track object with the earliest release of that song
 export async function GET({ url }) {
-  const track = url.searchParams.get('track');
-  const artist = url.searchParams.get('artist');
-  const year = url.searchParams.get('year');
+  const id = url.searchParams.get('id');
 
-  const query = `track:${track} artist:${artist} year:1900-${year}`;
+  if (!id) {
+    throw new Error('No ID provided');
+  }
+
+  const track = await spotify.tracks.get(id);
+
+  // Remove extras like " - Live", "(Remastered)", etc.
+  const trackNoExtras = removeSongExtraText(track.name);
+
+  const encodedTrack = encodeSearchQuery(trackNoExtras);
+  const encodedArtist = encodeSearchQuery(track.artists[0].name);
+  const encodedYear = encodeSearchQuery(track.album.release_date.slice(0, 4));
+
+  const query = `${encodedTrack}%20artist:${encodedArtist}%20year:1900-${encodedYear}`;
 
   const results = (await spotify.search(query, ['track'], undefined, 5)).tracks.items;
 
-  const earliestRelease = results?.sort((a, b) =>
+  if (!results) return Response.json(null);
+
+  const filteredResults = results
+    // Exclude tracks with different names
+    .filter((result) => result.name === trackNoExtras)
+    // Exclude tracks from a different artist
+    .filter((result) => result.artists[0].name === track.artists[0].name)
+    // Exclude singles
+    .filter((result) => result.album.album_type === 'album');
+
+  console.log(filteredResults);
+
+  const earliestRelease = filteredResults.sort((a, b) =>
     dayjs(a.album.release_date).isSameOrBefore(dayjs(b.album.release_date)) ? -1 : 1
   )[0];
 
-  if (!earliestRelease) return Response.json({});
+  if (!earliestRelease) return Response.json(null);
 
   return Response.json(earliestRelease);
 }


### PR DESCRIPTION
- Do not pass around a `Promise` when storing `earlierRelease`
- Debounce the `getEarliestRelease` query to prevent multiple calls in quick succession which can trigger rate limiting
- Check explicitly for `response.ok` and _do not `return`_ from the errored state, which breaks the page
- Add a new helper function for `encodeSearchQuery` and add tests
- Filter earlier releases to exclude singles, songs with a different title, and songs from a different artist
  - Handles "Waterloo" returning an earlier version for "Waterloo - Swedish Version"
  - Handles "The Final Countdown" returning a totally different song
- Strip song extras like "- Live" from the search query in order to find earlier releases when a remix, remastered version, or live version is searched
- Change button text from "Keep newer release" to "Keep _this_ release"  
- Resolves #152 
- Resolves #146 