### PR TITLE
feat: Preview stripped title in song preview selection

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "@radix-ui/colors": "^3.0.0",
     "@spotify/web-api-ts-sdk": "^1.1.2",
     "@supabase/supabase-js": "^2.38.4",
-    "@types/canvas-confetti": "^1.6.3",
     "@vercel/analytics": "^1.1.1",
     "dayjs": "^1.11.10",
     "satori": "^0.10.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,9 +14,6 @@ dependencies:
   '@supabase/supabase-js':
     specifier: ^2.38.4
     version: 2.38.4
-  '@types/canvas-confetti':
-    specifier: ^1.6.3
-    version: 1.6.3
   '@vercel/analytics':
     specifier: ^1.1.1
     version: 1.1.1
@@ -737,10 +734,6 @@ packages:
     dependencies:
       tslib: 2.6.2
     dev: true
-
-  /@types/canvas-confetti@1.6.3:
-    resolution: {integrity: sha512-yKVMDzWJ6g0s8TDI3VERfLMCOh0oHqZUnfK+o3VVjR2mFsLynUgb2lR+3IRaEJMza3BKbV9pkoirmM23YhKozA==}
-    dev: false
 
   /@types/chai-subset@1.3.5:
     resolution: {integrity: sha512-c2mPnw+xHtXDoHmdtcCXGwyLMiauiAyxWMzhGpqHC4nqI/Y5G2XhTampslK2rb59kpcuHon03UH8W6iYUzw88A==}

--- a/src/lib/components/SongPreview.svelte
+++ b/src/lib/components/SongPreview.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { getYearsEarlierText, smartquotes } from '$lib/helpers';
+  import { getYearsEarlierText, removeSongExtraText, smartquotes } from '$lib/helpers';
   import type { Track } from '@spotify/web-api-ts-sdk';
   import { slide } from 'svelte/transition';
   import CloseCircleIcon from '~icons/ri/close-circle-line';
@@ -31,7 +31,7 @@
   <div class="selectedSongContents">
     <img class="selectedAlbum" src={song.album.images[0].url} alt={song.name} />
     <div class="selectedLabel">
-      <div class="selectedName">{smartquotes(song.name)}</div>
+      <div class="selectedName">{smartquotes(removeSongExtraText(song.name))}</div>
       <div>{song.artists.map((artist) => artist.name).join(', ')}</div>
       <div class="selectedAlbumNameAndYear">
         <em>{smartquotes(song.album.name)}</em> &middot;{' '}

--- a/src/routes/cover/[slug]/+page.svelte
+++ b/src/routes/cover/[slug]/+page.svelte
@@ -28,9 +28,10 @@
         ((window.innerWidth - minWidth) / (maxWidth - minWidth)) * (maxValue - minValue) + minValue;
 
       const scalar = interpolate(1.4, 1.8);
-      const velocity = interpolate(60, 100);
+      const velocity = interpolate(85, 120);
       const angle = interpolate(20, 45);
-      const count = interpolate(30, 60);
+      const count = interpolate(40, 80);
+      const spread = interpolate(8, 20);
 
       const sharedProps: Partial<IConfettiOptions> = {
         scalar: scalar,
@@ -46,27 +47,28 @@
           count,
           startVelocity: velocity - 10,
           angle: center - angle,
-          origin: { x: 0, y: 1 }
+          origin: { x: 0, y: 1 },
+          spread
         },
         right: {
           count,
           startVelocity: velocity - 10,
           angle: center + angle,
-          origin: { x: 1, y: 1 }
+          origin: { x: 1, y: 1 },
+          spread
         },
         bottom: {
           count: count * 2,
           startVelocity: velocity,
           angle: center,
           origin: { x: 0.5, y: 1 },
-          drift: 0
+          spread: spread * 2.5
         }
       };
 
       confetti({
         ...sharedProps,
-        ...directionalProps[placement],
-        spread: placement === 'bottom' ? 30 : 10
+        ...directionalProps[placement]
       });
     };
 


### PR DESCRIPTION
- Song titles are stripped in the final page, they should be stripped when previewing the data on the submission page
- Remove `@types/canvas-confetti`
- Adjust confetti settings

Before:
<img width="693" alt="image" src="https://github.com/evadecker/genderswap.fm/assets/4117920/f7a89d93-2e50-428f-98eb-661677dde577">

After:
<img width="687" alt="image" src="https://github.com/evadecker/genderswap.fm/assets/4117920/1d47b297-1cc9-4b7c-a28f-460ea5788507">