### PR TITLE
feat: Dimensional album art

### DIFF
--- a/src/lib/components/CoverCard.svelte
+++ b/src/lib/components/CoverCard.svelte
@@ -93,6 +93,15 @@
 
     &:not(:empty) {
       box-shadow: var(--shadow-album-s);
+
+      &::after {
+        content: '';
+        position: absolute;
+        inset: 0;
+        border-radius: var(--radius-album);
+        box-shadow: var(--shadow-album-inset-s);
+        mix-blend-mode: luminosity;
+      }
     }
 
     img {
@@ -112,15 +121,6 @@
       width: 60%;
       transform: rotate(6deg) translateX(-6%);
       transform-origin: 0 0;
-    }
-
-    &:not(:empty):after {
-      content: '';
-      position: absolute;
-      inset: 0;
-      border-radius: var(--radius-album);
-      box-shadow: var(--shadow-album-inset-s);
-      mix-blend-mode: luminosity;
     }
   }
 

--- a/src/lib/components/CoverCard.svelte
+++ b/src/lib/components/CoverCard.svelte
@@ -92,9 +92,7 @@
     position: relative;
 
     &:not(:empty) {
-      // https://shadows.brumm.af/
-      box-shadow: 0.2px 0.2px 0.4px rgba(0, 0, 0, 0.028), 0.5px 0.5px 1px rgba(0, 0, 0, 0.04),
-        1.2px 1.2px 2.4px rgba(0, 0, 0, 0.052), 4px 4px 8px rgba(0, 0, 0, 0.08);
+      box-shadow: var(--shadow-album-s);
     }
 
     img {

--- a/src/lib/components/CoverCard.svelte
+++ b/src/lib/components/CoverCard.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { smartquotes } from '$lib/helpers';
-  import { spring } from 'svelte/motion';
 
   type Album = {
     name: string;
@@ -14,6 +13,7 @@
   export let lazy: boolean = false;
 
   let isSkeleton = false;
+  if (!original && !cover && !slug) isSkeleton = true;
 </script>
 
 <div class="coverCard" class:placeholder={isSkeleton} aria-hidden={isSkeleton || undefined}>

--- a/src/lib/components/CoverCard.svelte
+++ b/src/lib/components/CoverCard.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { smartquotes } from '$lib/helpers';
+  import { spring } from 'svelte/motion';
 
   type Album = {
     name: string;
@@ -13,7 +14,6 @@
   export let lazy: boolean = false;
 
   let isSkeleton = false;
-  if (!original && !cover && !slug) isSkeleton = true;
 </script>
 
 <div class="coverCard" class:placeholder={isSkeleton} aria-hidden={isSkeleton || undefined}>
@@ -89,11 +89,12 @@
     overflow: hidden;
     aspect-ratio: 1;
     transition: transform 0.2s ease-in-out;
+    position: relative;
 
     &:not(:empty) {
       // https://shadows.brumm.af/
-      box-shadow: 0px 1.8px 3.6px rgba(0, 0, 0, 0.024), 0px 5px 10px rgba(0, 0, 0, 0.035),
-        0px 12.1px 24.1px rgba(0, 0, 0, 0.046), 0px 40px 80px rgba(0, 0, 0, 0.07);
+      box-shadow: 0.2px 0.2px 0.4px rgba(0, 0, 0, 0.028), 0.5px 0.5px 1px rgba(0, 0, 0, 0.04),
+        1.2px 1.2px 2.4px rgba(0, 0, 0, 0.052), 4px 4px 8px rgba(0, 0, 0, 0.08);
     }
 
     img {
@@ -113,6 +114,15 @@
       width: 60%;
       transform: rotate(6deg) translateX(-6%);
       transform-origin: 0 0;
+    }
+
+    &:not(:empty):after {
+      content: '';
+      position: absolute;
+      inset: 0;
+      border-radius: var(--radius-album);
+      box-shadow: var(--shadow-album-inset-s);
+      mix-blend-mode: luminosity;
     }
   }
 

--- a/src/lib/components/CoverComparison.svelte
+++ b/src/lib/components/CoverComparison.svelte
@@ -152,7 +152,7 @@
       object-fit: cover;
     }
 
-    &:after {
+    &::after {
       content: '';
       position: absolute;
       inset: 0;

--- a/src/lib/components/CoverComparison.svelte
+++ b/src/lib/components/CoverComparison.svelte
@@ -144,8 +144,7 @@
     border-radius: var(--radius-album);
     position: relative;
     z-index: 1;
-    box-shadow: 0.1px 0.4px 0.5px rgba(0, 0, 0, 0.028), 0.3px 1px 1.3px rgba(0, 0, 0, 0.04),
-      0.6px 2.4px 3px rgba(0, 0, 0, 0.052), 2px 8px 10px rgba(0, 0, 0, 0.08);
+    box-shadow: var(--shadow-album-l);
 
     img {
       width: 100%;

--- a/src/lib/components/CoverComparison.svelte
+++ b/src/lib/components/CoverComparison.svelte
@@ -144,14 +144,22 @@
     border-radius: var(--radius-album);
     position: relative;
     z-index: 1;
-    box-shadow: 0px 1.7px 2.2px rgba(0, 0, 0, 0.02), 0px 4px 5.3px rgba(0, 0, 0, 0.028),
-      0px 7.5px 10px rgba(0, 0, 0, 0.035), 0px 13.4px 17.9px rgba(0, 0, 0, 0.042),
-      0px 25.1px 33.4px rgba(0, 0, 0, 0.05), 0px 60px 80px rgba(0, 0, 0, 0.07);
+    box-shadow: 0.1px 0.4px 0.5px rgba(0, 0, 0, 0.028), 0.3px 1px 1.3px rgba(0, 0, 0, 0.04),
+      0.6px 2.4px 3px rgba(0, 0, 0, 0.052), 2px 8px 10px rgba(0, 0, 0, 0.08);
 
     img {
       width: 100%;
       height: 100%;
       object-fit: cover;
+    }
+
+    &:after {
+      content: '';
+      position: absolute;
+      inset: 0;
+      border-radius: var(--radius-album);
+      box-shadow: var(--shadow-album-inset-l);
+      mix-blend-mode: luminosity;
     }
   }
 

--- a/src/lib/components/SongPreview.svelte
+++ b/src/lib/components/SongPreview.svelte
@@ -29,7 +29,9 @@
 
 <div class="selectedSong">
   <div class="selectedSongContents">
-    <img class="selectedAlbum" src={song.album.images[0].url} alt={song.name} />
+    <div class="selectedAlbum">
+      <img src={song.album.images[0].url} alt={song.name} />
+    </div>
     <div class="selectedLabel">
       <div class="selectedName">{smartquotes(removeSongExtraText(song.name))}</div>
       <div>{song.artists.map((artist) => artist.name).join(', ')}</div>
@@ -99,6 +101,17 @@
     height: calc(var(--space-3xl) * 2);
     flex-shrink: 0;
     min-width: none;
+    box-shadow: var(--shadow-album-s);
+    position: relative;
+    overflow: hidden;
+
+    &::after {
+      content: '';
+      position: absolute;
+      inset: 0;
+      border-radius: var(--radius-album);
+      box-shadow: var(--shadow-album-inset-s);
+    }
   }
 
   .selectedLabel {
@@ -179,7 +192,7 @@
 
         &:hover {
           background: var(--pink-9);
-          color: var(--mauve-12);
+          color: white;
         }
       }
 

--- a/src/lib/styles/theme.css
+++ b/src/lib/styles/theme.css
@@ -116,13 +116,18 @@
   --radius-m: var(--space-m);
   --radius-l: var(--space-l);
   --radius-full: 9999px;
-  --radius-album: max(3px, 2%);
+  --radius-album: max(4px, 2%);
 
   /* Font weights */
   --font-weight-normal: 400;
   --font-weight-bold: 600;
 
   /* Shadows */
+  /* https://shadows.brumm.af/ */
+  --shadow-album-s: 0.2px 0.2px 0.4px rgba(0, 0, 0, 0.028), 0.5px 0.5px 1px rgba(0, 0, 0, 0.04),
+    1.2px 1.2px 2.4px rgba(0, 0, 0, 0.052), 4px 4px 8px rgba(0, 0, 0, 0.08);
+  --shadow-album-l: 0.1px 0.4px 0.5px rgba(0, 0, 0, 0.028), 0.3px 1px 1.3px rgba(0, 0, 0, 0.04),
+    0.6px 2.4px 3px rgba(0, 0, 0, 0.052), 2px 8px 10px rgba(0, 0, 0, 0.08);
   --shadow-album-inset-s: inset 1px -1px 2px rgba(0, 0, 0, 0.2),
     inset -1px -1px 2px rgba(0, 0, 0, 0.2), inset 0 1px 4px -1px rgba(255, 255, 255, 0.3);
   --shadow-album-inset-l: inset 2px -2px 4px rgba(0, 0, 0, 0.2),

--- a/src/lib/styles/theme.css
+++ b/src/lib/styles/theme.css
@@ -116,9 +116,15 @@
   --radius-m: var(--space-m);
   --radius-l: var(--space-l);
   --radius-full: 9999px;
-  --radius-album: max(3px, 1%);
+  --radius-album: max(3px, 2%);
 
   /* Font weights */
   --font-weight-normal: 400;
   --font-weight-bold: 600;
+
+  /* Shadows */
+  --shadow-album-inset-s: inset 1px -1px 2px rgba(0, 0, 0, 0.2),
+    inset -1px -1px 2px rgba(0, 0, 0, 0.2), inset 0 1px 4px -1px rgba(255, 255, 255, 0.3);
+  --shadow-album-inset-l: inset 2px -2px 4px rgba(0, 0, 0, 0.2),
+    inset -2px -2px 4px rgba(0, 0, 0, 0.2), inset 0 2px 8px -2px rgba(255, 255, 255, 0.3);
 }

--- a/src/routes/api/getEarliestRelease/+server.ts
+++ b/src/routes/api/getEarliestRelease/+server.ts
@@ -39,8 +39,6 @@ export async function GET({ url }) {
     // Exclude singles
     .filter((result) => result.album.album_type === 'album');
 
-  console.log(filteredResults);
-
   const earliestRelease = filteredResults.sort((a, b) =>
     dayjs(a.album.release_date).isSameOrBefore(dayjs(b.album.release_date)) ? -1 : 1
   )[0];


### PR DESCRIPTION
- We're adding shadows back to UI??? Can we _do_ that????
- Convert album shadows to CSS variables for reuse
- Apply shadows to all album art
- Remove a random `console.log` statement
- Increase album art radius

Before (no shadows):
<img width="1422" alt="image" src="https://github.com/evadecker/genderswap.fm/assets/4117920/c60051cc-977b-43be-84e2-23b5163a195c">
<img width="1420" alt="image" src="https://github.com/evadecker/genderswap.fm/assets/4117920/9cb34872-4f9f-41cb-8b46-6bfe29449944">


After (with shadows):
<img width="1479" alt="image" src="https://github.com/evadecker/genderswap.fm/assets/4117920/1b82022c-6e53-46c1-9e09-b1bc4a9556a2">
<img width="1480" alt="image" src="https://github.com/evadecker/genderswap.fm/assets/4117920/8bef1ae0-a118-43db-a0ec-9ff9cb4d1654">