### PR TITLE
fix: Refine inner shadow

### DIFF
--- a/src/lib/components/CoverCard.svelte
+++ b/src/lib/components/CoverCard.svelte
@@ -99,7 +99,6 @@
         inset: 0;
         border-radius: var(--radius-album);
         box-shadow: var(--shadow-album-inset-s);
-        mix-blend-mode: multiply;
       }
     }
 

--- a/src/lib/components/CoverCard.svelte
+++ b/src/lib/components/CoverCard.svelte
@@ -84,9 +84,8 @@
   }
 
   .album {
-    background-color: var(--mauve-4);
+    background: var(--mauve-3);
     border-radius: var(--radius-album);
-    overflow: hidden;
     aspect-ratio: 1;
     transition: transform 0.2s ease-in-out;
     position: relative;
@@ -100,7 +99,7 @@
         inset: 0;
         border-radius: var(--radius-album);
         box-shadow: var(--shadow-album-inset-s);
-        mix-blend-mode: luminosity;
+        mix-blend-mode: multiply;
       }
     }
 
@@ -108,6 +107,7 @@
       width: 100%;
       height: 100%;
       aspect-ratio: 1;
+      border-radius: var(--radius-album);
       object-fit: cover;
     }
 

--- a/src/lib/components/CoverComparison.svelte
+++ b/src/lib/components/CoverComparison.svelte
@@ -159,7 +159,6 @@
       inset: 0;
       border-radius: var(--radius-album);
       box-shadow: var(--shadow-album-inset-l);
-      mix-blend-mode: multiply;
     }
   }
 

--- a/src/lib/components/CoverComparison.svelte
+++ b/src/lib/components/CoverComparison.svelte
@@ -150,6 +150,7 @@
       width: 100%;
       height: 100%;
       object-fit: cover;
+      border-radius: var(--radius-album);
     }
 
     &::after {
@@ -158,7 +159,7 @@
       inset: 0;
       border-radius: var(--radius-album);
       box-shadow: var(--shadow-album-inset-l);
-      mix-blend-mode: luminosity;
+      mix-blend-mode: multiply;
     }
   }
 

--- a/src/lib/styles/theme.css
+++ b/src/lib/styles/theme.css
@@ -124,12 +124,12 @@
 
   /* Shadows */
   /* https://shadows.brumm.af/ */
-  --shadow-album-s: 0.2px 0.2px 0.4px rgba(0, 0, 0, 0.028), 0.5px 0.5px 1px rgba(0, 0, 0, 0.04),
-    1.2px 1.2px 2.4px rgba(0, 0, 0, 0.052), 4px 4px 8px rgba(0, 0, 0, 0.08);
+  --shadow-album-s: 0px 0.3px 0.2px rgba(0, 0, 0, 0.042), 0px 0.8px 0.6px rgba(0, 0, 0, 0.06),
+    0px 1.8px 1.5px rgba(0, 0, 0, 0.078), 0px 6px 5px rgba(0, 0, 0, 0.12);
   --shadow-album-l: 0.1px 0.4px 0.5px rgba(0, 0, 0, 0.028), 0.3px 1px 1.3px rgba(0, 0, 0, 0.04),
     0.6px 2.4px 3px rgba(0, 0, 0, 0.052), 2px 8px 10px rgba(0, 0, 0, 0.08);
-  --shadow-album-inset-s: inset 1px -1px 2px rgba(0, 0, 0, 0.2),
-    inset -1px -1px 2px rgba(0, 0, 0, 0.2), inset 0 1px 4px -1px rgba(255, 255, 255, 0.3);
-  --shadow-album-inset-l: inset 2px -2px 4px rgba(0, 0, 0, 0.2),
-    inset -2px -2px 4px rgba(0, 0, 0, 0.2), inset 0 2px 8px -2px rgba(255, 255, 255, 0.3);
+  --shadow-album-inset-s: inset 1px -1px 2px rgba(0, 0, 0, 0.1),
+    inset -1px -1px 2px rgba(0, 0, 0, 0.1);
+  --shadow-album-inset-l: inset 2px -2px 4px rgba(0, 0, 0, 0.1),
+    inset -2px -2px 4px rgba(0, 0, 0, 0.1);
 }

--- a/src/lib/styles/theme.css
+++ b/src/lib/styles/theme.css
@@ -124,12 +124,11 @@
 
   /* Shadows */
   /* https://shadows.brumm.af/ */
-  --shadow-album-s: 0px 0.3px 0.2px rgba(0, 0, 0, 0.042), 0px 0.8px 0.6px rgba(0, 0, 0, 0.06),
-    0px 1.8px 1.5px rgba(0, 0, 0, 0.078), 0px 6px 5px rgba(0, 0, 0, 0.12);
-  --shadow-album-l: 0.1px 0.4px 0.5px rgba(0, 0, 0, 0.028), 0.3px 1px 1.3px rgba(0, 0, 0, 0.04),
-    0.6px 2.4px 3px rgba(0, 0, 0, 0.052), 2px 8px 10px rgba(0, 0, 0, 0.08);
-  --shadow-album-inset-s: inset 1px -1px 2px rgba(0, 0, 0, 0.1),
-    inset -1px -1px 2px rgba(0, 0, 0, 0.1);
-  --shadow-album-inset-l: inset 2px -2px 4px rgba(0, 0, 0, 0.1),
-    inset -2px -2px 4px rgba(0, 0, 0, 0.1);
+  --shadow-album-s: 0px 0.4px 0.7px rgba(0, 0, 0, 0.12), 0px 1.2px 1.9px rgba(0, 0, 0, 0.111),
+    0px 3.1px 4.4px rgba(0, 0, 0, 0.101), 0px 12px 12px rgba(0, 0, 0, 0.081);
+  --shadow-album-l: 0px 1.1px 1.8px rgba(0, 0, 0, 0.12), 0px 3.2px 5.2px rgba(0, 0, 0, 0.111),
+    0px 8.3px 11.6px rgba(0, 0, 0, 0.101), 0px 32px 32px rgba(0, 0, 0, 0.081);
+  --shadow-album-inset-s: inset 0 -1px 1px rgba(0, 0, 0, 0.05),
+    inset 0 -0.5px 0.5px rgba(0, 0, 0, 0.15);
+  --shadow-album-inset-l: inset 0 -2px 2px rgba(0, 0, 0, 0.05), inset 0 -1px 1px rgba(0, 0, 0, 0.15);
 }


### PR DESCRIPTION
- No highlight, shadows only
- Tighten drop shadow
- Fix border radius issue when parent set to `overflow: hidden`

Before:
<img width="1269" alt="image" src="https://github.com/evadecker/genderswap.fm/assets/4117920/0e01c29b-072a-4e69-af50-cc04b7383c9f">

After:
<img width="1265" alt="image" src="https://github.com/evadecker/genderswap.fm/assets/4117920/90dd768e-920a-459a-8160-53974fd796e0">
