### PR TITLE
feat: Link artists to filtered query, open Spotify links in new tab

### DIFF
--- a/src/lib/components/CoverComparison.svelte
+++ b/src/lib/components/CoverComparison.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { slugify, smartquotes } from '$lib/helpers';
+  import { getArtistLink, slugify, smartquotes } from '$lib/helpers';
   import type { Cover } from '../../routes/cover/[slug]/+page.server';
   import SpotifyIcon from '~icons/ri/spotify-fill';
 
@@ -29,12 +29,21 @@
       />
     </div>
     <div class="details">
-      <a href={originalSong.url} itemprop="url" aria-label="Open in Spotify" class="song-link">
+      <a
+        href={originalSong.url}
+        target="_blank"
+        itemprop="url"
+        aria-label="Open in Spotify"
+        class="song-link"
+      >
         <SpotifyIcon />
         Listen to original
       </a>
       <h2 class="artist" itemprop="byArtist">
-        {smartquotes(originalSong.artists.join(', ')) ?? 'Loading...'}
+        {#each originalSong.artists as artist, i}
+          <a href={getArtistLink(artist)}>{smartquotes(artist)}</a
+          >{#if i < originalSong.artists.length - 1}{`, `}{/if}
+        {/each}
       </h2>
       <time class="album-year" itemprop="datePublished">
         {originalSong.album_year}
@@ -52,12 +61,21 @@
       />
     </div>
     <div class="details">
-      <a href={coverSong.url} itemprop="url" aria-label="Open in Spotify" class="song-link">
+      <a
+        href={coverSong.url}
+        target="_blank"
+        itemprop="url"
+        aria-label="Open in Spotify"
+        class="song-link"
+      >
         <SpotifyIcon />
         Listen to cover
       </a>
       <h2 class="artist" itemprop="byArtist">
-        {smartquotes(coverSong.artists.join(', ')) ?? 'Loading...'}
+        {#each coverSong.artists as artist, i}
+          <a href={getArtistLink(artist)}>{smartquotes(artist)}</a
+          >{#if i < coverSong.artists.length - 1}{`, `}{/if}
+        {/each}
       </h2>
       <time class="album-year" itemprop="datePublished">
         {coverSong.album_year}
@@ -194,6 +212,11 @@
 
   .artist {
     font-size: var(--step-3);
+
+    a:hover {
+      text-decoration: underline;
+      text-decoration-color: var(--mauve-9);
+    }
   }
 
   .album-year,

--- a/src/lib/helpers.test.ts
+++ b/src/lib/helpers.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   encodeSearchQuery,
+  getArtistLink,
   getMaxCharacterHelpText,
   getReadableTitle,
   getSortedTags,
@@ -225,5 +226,11 @@ describe('encodeSearchQuery', () => {
     expect(encodeSearchQuery("why'd you only call me when you're high?")).toBe(
       'why%27d%20you%20only%20call%20me%20when%20you%27re%20high'
     );
+  });
+});
+
+describe('getArtistLink', () => {
+  it('should return a filtered query to the homepage', () => {
+    expect(getArtistLink('Phoebe Bridgers')).toBe('/?q=Phoebe%20Bridgers');
   });
 });

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -97,3 +97,7 @@ export const encodeSearchQuery = (query: string) => {
       .replace(/\?/g, '') // Remove question marks
   ).replace(/'/g, '%27'); // Replace all single quotes with %27;
 };
+
+export const getArtistLink = (artist: string) => {
+  return `/?q=${encodeURIComponent(artist)}`;
+};

--- a/src/routes/cover/[slug]/+page.svelte
+++ b/src/routes/cover/[slug]/+page.svelte
@@ -7,7 +7,7 @@
   import { page } from '$app/stores';
   import { onMount } from 'svelte';
   import { confetti } from 'tsparticles-confetti';
-  import { getSortedTags } from '$lib/helpers.js';
+  import { getArtistLink, getSortedTags } from '$lib/helpers.js';
   import Sparkle from '$lib/components/Sparkle.svelte';
   import type { IConfettiOptions } from 'tsparticles-confetti/types/IConfettiOptions.js';
 
@@ -96,8 +96,9 @@
     {data.pageTitle}{#if isNew}<Sparkle />{/if}
   </h1>
   <div class="subtitle">
-    <strong>{data.cover.artists[0]}</strong> covering{' '}
-    <strong>{data.original.artists[0]}</strong>
+    <a class="artist" href={getArtistLink(data.cover.artists[0])}>{data.cover.artists[0]}</a>
+    covering{' '}
+    <a class="artist" href={getArtistLink(data.original.artists[0])}>{data.original.artists[0]}</a>
   </div>
   {#if data.description}
     <p class="description">{data.description}</p>
@@ -145,6 +146,15 @@
     margin-block-start: var(--space-m);
     margin-block-end: var(--space-l);
     text-wrap: balance;
+  }
+
+  .artist {
+    font-weight: var(--font-weight-bold);
+
+    &:hover {
+      text-decoration: underline;
+      text-decoration-color: var(--mauve-9);
+    }
   }
 
   .description {


### PR DESCRIPTION
- Add inline links over artist names on detail page
- Add `target="_blank"` to Spotify links to open in new tab
- Resolves #172 