### PR TITLE
fix: Form spacing glitch

### DIFF
--- a/src/lib/components/GenderSelect.svelte
+++ b/src/lib/components/GenderSelect.svelte
@@ -25,10 +25,10 @@
 </script>
 
 <fieldset use:melt={$root} class="genderSelect" {name}>
-  <legend class="label" aria-invalid={errors ? 'true' : undefined}>
+  <div class="label" aria-invalid={errors ? 'true' : undefined}>
     Vocals include{' '}
     <span class="instructions">select all that apply</span>
-  </legend>
+  </div>
   <div class="toggleWrapper">
     <div class="toggleGroup">
       <button use:melt={$item('male')} aria-label={`Select men`}>


### PR DESCRIPTION
Previously, there was extra space under each `GenderSelect` component when the page rendered, and then the space would shrink once the user had interacted with the page.

I believe this was an artifact of the way browsers handle `legend` within `fieldset`, and styles being calculated differently server side versus client side. In any case, replacing `legend` with `div` fixes the issue.