### PR TITLE
feat: Check for existing cover during entry

### DIFF
--- a/src/lib/components/SongPreview.svelte
+++ b/src/lib/components/SongPreview.svelte
@@ -1,16 +1,28 @@
 <script lang="ts">
-  import { getYearsEarlierText, removeSongExtraText, smartquotes } from '$lib/helpers';
+  import {
+    getReadableTitle,
+    getYearsEarlierText,
+    removeSongExtraText,
+    smartquotes
+  } from '$lib/helpers';
   import type { Track } from '@spotify/web-api-ts-sdk';
   import { slide } from 'svelte/transition';
   import CloseCircleIcon from '~icons/ri/close-circle-line';
   import HistoryIcon from '~icons/ri/history-line';
   import CheckIcon from '~icons/ri/check-line';
+  import AlertIcon from '~icons/ri/alert-line';
   import type { MouseEventHandler } from 'svelte/elements';
+  import type { ExistingCover } from '../../routes/api/getCover/+server';
+  import dayjs from 'dayjs';
+  import relativeTime from 'dayjs/plugin/relativeTime';
 
   export let song: Track;
+  export let existingCover: ExistingCover | null;
   export let earlierRelease: Track | null;
   export let onUseEarlierRelease: () => void;
   export let onClearSelection: () => void;
+
+  dayjs.extend(relativeTime);
 
   let wasKeepThisReleaseClicked = false;
   let wasEarlierReleaseClicked = false;
@@ -45,8 +57,28 @@
     </button>
   </div>
 
-  {#if earlierRelease && !wasKeepThisReleaseClicked}
-    <div class="earlierReleaseBanner" transition:slide>
+  {#if existingCover}
+    <div class="banner" transition:slide>
+      <div class="bannerContents">
+        <AlertIcon />
+        <div class="bannerLabel">
+          <strong class="bannerTitle"
+            >This cover was already submitted {dayjs(existingCover.created_at).fromNow()}</strong
+          >
+          <p>
+            <a href={`/cover/${existingCover.slug}`}
+              >{getReadableTitle({
+                originalName: existingCover.original.name,
+                originalArtists: existingCover.original.artists,
+                coverArtists: existingCover.cover.artists
+              })}</a
+            >
+          </p>
+        </div>
+      </div>
+    </div>
+  {:else if earlierRelease && !wasKeepThisReleaseClicked}
+    <div class="banner" transition:slide>
       {#if earlierRelease.id === song.id || wasEarlierReleaseClicked}
         <div class="bannerContents">
           <CheckIcon />
@@ -149,7 +181,7 @@
     }
   }
 
-  .earlierReleaseBanner {
+  .banner {
     border-top: 1px solid var(--mauve-6);
     padding: var(--space-m);
     display: flex;
@@ -166,6 +198,10 @@
 
     p {
       font-size: var(--step--1);
+
+      a {
+        text-decoration: underline;
+      }
     }
   }
 

--- a/src/lib/components/SongSelect.svelte
+++ b/src/lib/components/SongSelect.svelte
@@ -6,12 +6,14 @@
   import SearchIcon from '~icons/ri/search-line';
   import { scale } from 'svelte/transition';
   import { encodeSearchQuery } from '$lib/helpers';
+  import type { ExistingCover } from '../../routes/api/getCover/+server';
 
   export let name: string;
   export let value: Track | undefined;
   export let errors: string[] | undefined = undefined;
 
   let discoveredEarlierRelease: Track | null;
+  let discoveredExistingCover: ExistingCover | null;
   let searchResults: Track[] | undefined = undefined;
 
   let debounceTimer: ReturnType<typeof setTimeout>;
@@ -28,7 +30,10 @@
     preventScroll: false,
     onSelectedChange: ({ next }) => {
       if (next) {
-        debounce(() => checkForEarlierRelease(next.value));
+        debounce(() => {
+          checkForEarlierRelease(next.value);
+          checkForExistingCover(next.value);
+        });
         value = next.value;
       }
       return next;
@@ -36,6 +41,22 @@
   });
 
   $: selected.set(value ? { value } : undefined);
+
+  const checkForExistingCover = async (track: Track) => {
+    console.log('checking');
+    try {
+      const response = await fetch(`/api/getCover?id=${track.id}`, {
+        method: 'GET'
+      });
+
+      if (response.ok) discoveredExistingCover = await response.json();
+      console.log(discoveredExistingCover);
+    } catch (error) {
+      if (error instanceof Error) {
+        console.error(error.message);
+      }
+    }
+  };
 
   const checkForEarlierRelease = async (track: Track) => {
     try {
@@ -90,6 +111,7 @@
   };
 
   const handleClearSelection = () => {
+    discoveredExistingCover = null;
     discoveredEarlierRelease = null;
     inputValue.set('');
     value = undefined;
@@ -113,6 +135,7 @@
   {#if value}
     <SongPreview
       song={value}
+      existingCover={discoveredExistingCover}
       earlierRelease={discoveredEarlierRelease}
       onUseEarlierRelease={handleUseEarlierRelease}
       onClearSelection={handleClearSelection}
@@ -127,7 +150,7 @@
           use:melt={$input}
           class="searchInput"
           type="search"
-          placeholder="Search or enter Spotify song URL"
+          placeholder={`Search or enter Spotify song URL`}
           aria-invalid={errors ? 'true' : undefined}
         />
       </label>

--- a/src/lib/components/SongSelect.svelte
+++ b/src/lib/components/SongSelect.svelte
@@ -28,6 +28,11 @@
     helpers: { isSelected, isHighlighted }
   } = createCombobox<Track>({
     preventScroll: false,
+    positioning: {
+      placement: 'bottom',
+      flip: false,
+      sameWidth: true
+    },
     onSelectedChange: ({ next }) => {
       if (next) {
         debounce(() => {
@@ -150,7 +155,7 @@
           use:melt={$input}
           class="searchInput"
           type="search"
-          placeholder={`Search or enter Spotify song URL`}
+          placeholder="Search songs or paste Spotify URL"
           aria-invalid={errors ? 'true' : undefined}
         />
       </label>

--- a/src/routes/api/getCover/+server.ts
+++ b/src/routes/api/getCover/+server.ts
@@ -1,0 +1,38 @@
+import { supabase } from '$lib/supabase';
+
+export type ExistingCover = {
+  original: {
+    name: string;
+    artists: string[];
+  };
+  cover: {
+    artists: string[];
+  };
+  slug: string;
+  created_at: string;
+};
+
+// Given a Spotify track ID, returns a new Track object with the earliest release of that song
+export async function GET({ url }) {
+  const id = url.searchParams.get('id');
+
+  if (!id) {
+    throw new Error('No ID provided');
+  }
+
+  const { data: existingCover } = await supabase
+    .from('covers')
+    .select(
+      `slug,
+      created_at,
+      original:original_id(name, artists),
+      cover:cover_id(artists)`
+    )
+    .eq('cover_id', id)
+    .returns<ExistingCover>()
+    .single();
+
+  if (!existingCover) return Response.json(null);
+
+  return Response.json(existingCover);
+}

--- a/src/routes/cover/[slug]/+page.server.ts
+++ b/src/routes/cover/[slug]/+page.server.ts
@@ -23,8 +23,7 @@ export async function load({ params: { slug } }) {
     created_at,
     description,
     contributor,
-    tags
-  `
+    tags`
     )
     .eq('slug', slug!!)
     .returns<Cover>()

--- a/src/routes/new/+page.svelte
+++ b/src/routes/new/+page.svelte
@@ -53,20 +53,20 @@
 <form class="submitForm" method="POST" use:enhance>
   <h1 class="header">Add a cover</h1>
   <Steps>
-    <Step title="Select the original">
-      <SongSelect name="original" bind:value={$form.original} errors={$errors.original} />
-      <GenderSelect
-        name="originalGenders"
-        bind:value={$form.originalGenders}
-        errors={$errors.originalGenders?._errors}
-      />
-    </Step>
     <Step title="Select the cover">
       <SongSelect name="cover" bind:value={$form.cover} errors={$errors.cover} />
       <GenderSelect
         name="coverGenders"
         bind:value={$form.coverGenders}
         errors={$errors.coverGenders?._errors}
+      />
+    </Step>
+    <Step title="Select the original">
+      <SongSelect name="original" bind:value={$form.original} errors={$errors.original} />
+      <GenderSelect
+        name="originalGenders"
+        bind:value={$form.originalGenders}
+        errors={$errors.originalGenders?._errors}
       />
     </Step>
     <Step title="Add thoughts">


### PR DESCRIPTION
- Put cover selection first in the new submission form
- Check for existing entries for the cover
- Force combobox popover to display beneath input, set `flip: false`
- Resolves #11 

<img width="603" alt="image" src="https://github.com/evadecker/genderswap.fm/assets/4117920/d816d043-c2cb-463b-b775-c21d8b66f605">
