### PR TITLE
feat: Add track previews

### DIFF
--- a/src/lib/components/AudioPreview.svelte
+++ b/src/lib/components/AudioPreview.svelte
@@ -55,8 +55,8 @@
     {#if state === 'paused'}
       <svg
         xmlns="http://www.w3.org/2000/svg"
-        width="16"
-        height="16"
+        width="1em"
+        height="1em"
         viewBox="0 0 24 24"
         fill="currentColor"
         stroke="currentColor"
@@ -69,8 +69,8 @@
     {:else}
       <svg
         xmlns="http://www.w3.org/2000/svg"
-        width="16"
-        height="16"
+        width="1em"
+        height="1em"
         viewBox="0 0 24 24"
         fill="currentColor"
         stroke="currentColor"
@@ -103,19 +103,20 @@
     all: unset;
     cursor: pointer;
     border-radius: var(--radius-full);
-    width: 32px;
-    height: 32px;
+    width: var(--space-xl);
+    height: var(--space-xl);
     display: flex;
     align-items: center;
     justify-content: center;
     border: 2.5px solid var(--mauve-12);
     color: var(--mauve-12);
     transition: all 0.2s ease-in-out;
+    font-size: var(--step--1);
 
     &.playing {
       background: var(--mauve-12);
       color: var(--mauve-1);
-      border-color: var(--mauve-1);
+      border-color: var(--mauve-3);
     }
   }
 </style>

--- a/src/lib/components/AudioPreview.svelte
+++ b/src/lib/components/AudioPreview.svelte
@@ -2,6 +2,7 @@
   import type { MouseEventHandler } from 'svelte/elements';
 
   export let src: string;
+  export let title: string;
 
   let state = 'paused';
   let audio: HTMLAudioElement;
@@ -43,7 +44,7 @@
     ? `background: conic-gradient(var(--pink-9) ${percent.toFixed(2)}%, transparent 0)`
     : undefined}
 >
-  <audio bind:this={audio} bind:currentTime={time} bind:duration>
+  <audio bind:this={audio} bind:currentTime={time} bind:duration {title}>
     <source {src} type="audio/mpeg" />
   </audio>
   <button

--- a/src/lib/components/AudioPreview.svelte
+++ b/src/lib/components/AudioPreview.svelte
@@ -1,0 +1,121 @@
+<script lang="ts">
+  import type { MouseEventHandler } from 'svelte/elements';
+
+  export let src: string;
+
+  let state = 'paused';
+  let audio: HTMLAudioElement;
+  let time = 0;
+  let duration: number;
+
+  const play = () => {
+    audio.play();
+    state = 'playing';
+  };
+
+  const pauseAndReset = () => {
+    audio.pause();
+    audio.currentTime = 0;
+    state = 'paused';
+  };
+
+  const handleButtonClick: MouseEventHandler<HTMLButtonElement> = (e) => {
+    e.preventDefault();
+
+    if (state === 'paused') {
+      play();
+    } else {
+      pauseAndReset();
+    }
+  };
+
+  $: percent = (time / duration) * 100;
+  $: if (percent > 99.5) pauseAndReset();
+</script>
+
+<div
+  class="progress"
+  role="progressbar"
+  aria-valuenow={parseFloat(percent.toFixed(2))}
+  aria-valuemin="0"
+  aria-valuemax="100"
+  style={state === 'playing'
+    ? `background: conic-gradient(var(--pink-9) ${percent.toFixed(2)}%, transparent 0)`
+    : undefined}
+>
+  <audio bind:this={audio} bind:currentTime={time} bind:duration>
+    <source {src} type="audio/mpeg" />
+  </audio>
+  <button
+    class="playPauseButton"
+    class:playing={state === 'playing'}
+    on:click={handleButtonClick}
+    aria-label={state === 'paused' ? 'Play' : 'Pause'}
+  >
+    {#if state === 'paused'}
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="16"
+        height="16"
+        viewBox="0 0 24 24"
+        fill="currentColor"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      >
+        <polygon points="5 3 19 12 5 21 5 3" transform="translate(2 0)" />
+      </svg>
+    {:else}
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="16"
+        height="16"
+        viewBox="0 0 24 24"
+        fill="currentColor"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      >
+        <rect x="6" y="4" width="4" height="16" />
+        <rect x="14" y="4" width="4" height="16" />
+      </svg>
+    {/if}
+  </button>
+</div>
+
+<style lang="scss">
+  .progress {
+    line-height: 0;
+    border-radius: var(--radius-full);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    justify-self: center;
+    padding: 2.5px;
+    margin: -2.5px;
+    width: min-content;
+    transition: all 0.2s ease-in-out;
+  }
+
+  .playPauseButton {
+    all: unset;
+    cursor: pointer;
+    border-radius: var(--radius-full);
+    width: 32px;
+    height: 32px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: 2.5px solid var(--mauve-12);
+    color: var(--mauve-12);
+    transition: all 0.2s ease-in-out;
+
+    &.playing {
+      background: var(--mauve-12);
+      color: var(--mauve-1);
+      border-color: var(--mauve-1);
+    }
+  }
+</style>

--- a/src/lib/components/SongPreview.svelte
+++ b/src/lib/components/SongPreview.svelte
@@ -54,7 +54,7 @@
       </div>
     </div>
     {#if song.preview_url}
-      <AudioPreview src={song.preview_url} />
+      <AudioPreview src={song.preview_url} title={smartquotes(removeSongExtraText(song.name))} />
     {/if}
     <button class="clearSelection" on:click={onClearSelection} aria-label="Remove selection">
       <CloseCircleIcon />

--- a/src/lib/components/SongPreview.svelte
+++ b/src/lib/components/SongPreview.svelte
@@ -15,6 +15,7 @@
   import type { ExistingCover } from '../../routes/api/getCover/+server';
   import dayjs from 'dayjs';
   import relativeTime from 'dayjs/plugin/relativeTime';
+  import AudioPreview from './AudioPreview.svelte';
 
   export let song: Track;
   export let existingCover: ExistingCover | null;
@@ -52,6 +53,9 @@
         {song.album.release_date.slice(0, 4)}
       </div>
     </div>
+    {#if song.preview_url}
+      <AudioPreview src={song.preview_url} />
+    {/if}
     <button class="clearSelection" on:click={onClearSelection} aria-label="Remove selection">
       <CloseCircleIcon />
     </button>
@@ -115,13 +119,13 @@
   .selectedSong {
     background: var(--mauve-3);
     border-radius: var(--radius-l);
-    overflow: hidden;
+    position: relative;
   }
 
   .selectedSongContents {
     padding: var(--space-m);
     display: grid;
-    grid-template: 'album content clear';
+    grid-template: 'album content preview';
     grid-template-columns: auto 1fr var(--space-2xl);
     align-items: center;
     gap: var(--space-m);
@@ -143,6 +147,12 @@
       inset: 0;
       border-radius: var(--radius-album);
       box-shadow: var(--shadow-album-inset-s);
+    }
+
+    img {
+      position: absolute;
+      inset: 0;
+      z-index: 0;
     }
   }
 
@@ -167,16 +177,24 @@
     justify-content: center;
     flex-shrink: 0;
     background: transparent;
-    width: var(--space-2xl);
-    height: var(--space-2xl);
+    width: var(--space-xl);
+    height: var(--space-xl);
     border-radius: var(--radius-full);
     cursor: pointer;
     line-height: 0;
-    color: var(--mauve-11);
+    color: var(--mauve-10);
+    position: absolute;
+    top: 0;
+    right: 0;
+    background: var(--mauve-1);
+    box-shadow: 0 0 0 3px var(--mauve-1);
+    transform: translate(50%, -50%);
+    font-size: 20px;
 
     @media (hover: hover) and (pointer: fine) {
       &:hover {
-        background: var(--mauve-4);
+        color: var(--red-9);
+        background: var(--red-4);
       }
     }
   }

--- a/src/lib/components/SongSelect.svelte
+++ b/src/lib/components/SongSelect.svelte
@@ -48,14 +48,12 @@
   $: selected.set(value ? { value } : undefined);
 
   const checkForExistingCover = async (track: Track) => {
-    console.log('checking');
     try {
       const response = await fetch(`/api/getCover?id=${track.id}`, {
         method: 'GET'
       });
 
       if (response.ok) discoveredExistingCover = await response.json();
-      console.log(discoveredExistingCover);
     } catch (error) {
       if (error instanceof Error) {
         console.error(error.message);

--- a/src/lib/helpers.test.ts
+++ b/src/lib/helpers.test.ts
@@ -88,6 +88,12 @@ describe('removeSongExtraText', () => {
       "Can't Get You out of My Head"
     );
   });
+
+  it('should remove bracketed text', () => {
+    expect(removeSongExtraText('What Was I Made For? [From The Motion Picture "Barbie"]')).toBe(
+      'What Was I Made For?'
+    );
+  });
 });
 
 describe('slugify', () => {

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -39,7 +39,10 @@ export const removeSongExtraText = (song: string) => {
     .trim()
     // Remove everything after a ' - ' in the song name
     // "Can't Get You out of My Head - Live at KEXP" -> "Can't Get You out of My Head"
-    .split(' - ')[0];
+    .split(' - ')[0]
+    // Remove bracketed text
+    // "What Was I Made For? [From The Motion Picture "Barbie"]" -> "What Was I Made For?"
+    .replace(/\s\[[^\]]*\]/g, '');
 
   return songNoExtras;
 };


### PR DESCRIPTION
- Add 30sec previews to song selection interface
- Relocate "clear song selection" button to top right of card
- Remove [bracketed text] from song titles
- Resolves #27 

<img width="702" alt="image" src="https://github.com/evadecker/genderswap.fm/assets/4117920/fe36c77d-38d1-4f09-ba33-9e1e436d05ca">
