### PR TITLE
feat: Add Spotify basic iframe embed

### DIFF
--- a/src/lib/components/AudioPlayer.svelte
+++ b/src/lib/components/AudioPlayer.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+  import { currentId } from '$lib/stores/playing';
+  import { fly } from 'svelte/transition';
+</script>
+
+{#if $currentId}
+  <div class="audio-player" transition:fly={{ y: 80 }}>
+    <iframe
+      style="border-radius: 14px"
+      src={`https://open.spotify.com/embed/track/${$currentId}`}
+      title="Spotify"
+      width="100%"
+      height="80"
+      frameBorder="0"
+      allowfullscreen={null}
+      allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
+    />
+  </div>
+{/if}
+
+<style lang="scss">
+  .audio-player {
+    width: 100%;
+    height: calc(80px + var(--space-m) * 2);
+    position: sticky;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    padding: var(--space-m);
+    display: flex;
+    gap: var(--space-s);
+    align-items: center;
+    z-index: 80;
+    background: linear-gradient(transparent, var(--mauve-1));
+  }
+</style>

--- a/src/lib/components/CoverComparison.svelte
+++ b/src/lib/components/CoverComparison.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { getArtistLink, slugify, smartquotes } from '$lib/helpers';
+  import { currentId } from '$lib/stores/playing';
   import type { Cover } from '../../routes/cover/[slug]/+page.server';
   import SpotifyIcon from '~icons/ri/spotify-fill';
 
@@ -11,6 +12,10 @@
   if (slugify(originalSong.name) !== slugify(coverSong.name)) {
     coveredAs = coverSong.name;
   }
+
+  const handleButtonClick = (id: string) => {
+    currentId.set(id);
+  };
 </script>
 
 <div class="compare">
@@ -29,16 +34,10 @@
       />
     </div>
     <div class="details">
-      <a
-        href={originalSong.url}
-        target="_blank"
-        itemprop="url"
-        aria-label="Open in Spotify"
-        class="song-link"
-      >
+      <button on:click={() => handleButtonClick(originalSong.id)} class="song-link">
         <SpotifyIcon />
         Listen to original
-      </a>
+      </button>
       <h2 class="artist" itemprop="byArtist">
         {#each originalSong.artists as artist, i}
           <a href={getArtistLink(artist)}>{smartquotes(artist)}</a
@@ -61,16 +60,10 @@
       />
     </div>
     <div class="details">
-      <a
-        href={coverSong.url}
-        target="_blank"
-        itemprop="url"
-        aria-label="Open in Spotify"
-        class="song-link"
-      >
+      <button on:click={() => handleButtonClick(coverSong.id)} class="song-link">
         <SpotifyIcon />
         Listen to cover
-      </a>
+      </button>
       <h2 class="artist" itemprop="byArtist">
         {#each coverSong.artists as artist, i}
           <a href={getArtistLink(artist)}>{smartquotes(artist)}</a
@@ -225,6 +218,7 @@
   }
 
   .song-link {
+    all: unset;
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -234,6 +228,7 @@
     background-color: var(--mauve-3);
     border-radius: var(--radius-full);
     font-weight: var(--font-weight-bold);
+    cursor: pointer;
 
     @media (hover: hover) and (pointer: fine) {
       &:hover {

--- a/src/lib/stores/playing.ts
+++ b/src/lib/stores/playing.ts
@@ -1,0 +1,3 @@
+import { writable } from 'svelte/store';
+
+export const currentId = writable<string>();

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -7,6 +7,7 @@
   import { inject } from '@vercel/analytics';
   import Header from '$lib/components/Header.svelte';
   import Footer from '$lib/components/Footer.svelte';
+  import AudioPlayer from '$lib/components/AudioPlayer.svelte';
 
   inject({ mode: dev ? 'development' : 'production' });
 </script>
@@ -16,6 +17,7 @@
   <slot />
 </main>
 <Footer />
+<AudioPlayer />
 
 <style>
   .main {


### PR DESCRIPTION
- Add Spotify's default iframe embed on song click
- Preview length only right now
- Opportunity for a deeper integration using the Web Playback API, which requires user authentication