### PR TITLE
fix: Use `font-display: fallback` and preload fonts

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -20,6 +20,27 @@
     />
     <link rel="apple-touch-icon" href="%sveltekit.assets%/apple-touch-icon.png" />
     <link rel="manifest" href="%sveltekit.assets%/manifest.json" />
+    <link
+      rel="preload"
+      href="%sveltekit.assets%/fonts/LabilGrotesk-Regular.woff2"
+      as="font"
+      type="font/woff2"
+      crossorigin
+    />
+    <link
+      rel="preload"
+      href="%sveltekit.assets%/fonts/LabilGrotesk-Bold.woff2"
+      as="font"
+      type="font/woff2"
+      crossorigin
+    />
+    <link
+      rel="preload"
+      href="%sveltekit.assets%/fonts/LabilGrotesk-RegularItalic.woff2"
+      as="font"
+      type="font/woff2"
+      crossorigin
+    />
     <title>Genderswap.fm</title>
     <meta property="og:type" content="website" />
     <meta property="og:locale" content="en_US" />

--- a/src/lib/styles/theme.css
+++ b/src/lib/styles/theme.css
@@ -35,7 +35,7 @@
   font-family: 'Labil Grotesk';
   font-style: normal;
   font-weight: 400;
-  font-display: swap;
+  font-display: fallback;
   src: url('/fonts/LabilGrotesk-Regular.woff2') format('woff2'),
     url('/fonts/LabilGrotesk-Regular.woff') format('woff');
 }
@@ -44,7 +44,7 @@
   font-family: 'Labil Grotesk';
   font-style: italic;
   font-weight: 400;
-  font-display: swap;
+  font-display: fallback;
   src: url('/fonts/LabilGrotesk-RegularItalic.woff2') format('woff2'),
     url('/fonts/LabilGrotesk-RegularItalic.woff') format('woff');
 }
@@ -53,7 +53,7 @@
   font-family: 'Labil Grotesk';
   font-style: normal;
   font-weight: 700;
-  font-display: swap;
+  font-display: fallback;
   src: url('/fonts/LabilGrotesk-Bold.woff2') format('woff2'),
     url('/fonts/LabilGrotesk-Bold.woff') format('woff');
 }


### PR DESCRIPTION
- Resolves #183 
- `preload` font files to minimize load time and flash of invisible text
- Change `font-display: swap` to `font-display: fallback`
  - `fallback` includes a short blocking gap at the beginning; if the fonts are not loaded after the block the fallback will be used, and then after a short delay the correct font will be loaded; `swap` which displays the fallback font immediately and causes text to jump on page change

https://savvy.co.il/en/blog/wordpress-speed/how-to-use-font-display-css/

![](https://savvy.co.il/wp-content/uploads/2019/08/font-face-rule-font-loading-2.jpg)