### PR TITLE
fix: Truncate list of artists in grid view

### DIFF
--- a/src/lib/components/CoverCard.svelte
+++ b/src/lib/components/CoverCard.svelte
@@ -53,11 +53,11 @@
     </h2>
     <div class="artist">
       {#if cover}
-        <span class="name">{formatArtists(cover.artists, 3)}</span>
+        <span class="name">{formatArtists(cover.artists)}</span>
       {/if}
       {#if original}
         <span class="covering"
-          >covering <span class="name">{formatArtists(original.artists, 3)}</span></span
+          >covering <span class="name">{formatArtists(original.artists)}</span></span
         >
       {/if}
     </div>

--- a/src/lib/components/CoverCard.svelte
+++ b/src/lib/components/CoverCard.svelte
@@ -15,6 +15,13 @@
   }: { original?: Album; cover?: Album; slug?: string; lazy?: boolean } = $props();
 
   const isSkeleton = $derived(!original && !cover && !slug);
+
+  function formatArtists(artists: string[]) {
+    const maxArtists = 2;
+    return artists.length > maxArtists
+      ? artists.slice(0, maxArtists).join(', ') + ` +${artists.length - maxArtists}`
+      : artists.join(', ');
+  }
 </script>
 
 <div class="coverCard" class:placeholder={isSkeleton} aria-hidden={isSkeleton || undefined}>
@@ -46,11 +53,11 @@
     </h2>
     <div class="artist">
       {#if cover}
-        <span class="name">{cover.artists.join(', ')}</span>
+        <span class="name">{formatArtists(cover.artists, 3)}</span>
       {/if}
       {#if original}
         <span class="covering"
-          >covering <span class="name">{original.artists.join(', ')}</span></span
+          >covering <span class="name">{formatArtists(original.artists, 3)}</span></span
         >
       {/if}
     </div>


### PR DESCRIPTION
Fix #286. Display `+n` when artists count is above 2.

![CleanShot 2025-07-08 at 23 30 54@2x](https://github.com/user-attachments/assets/db88741e-5b70-4eb7-a181-22f34f9e8186)
